### PR TITLE
Interleave matrix scan with LED PWM, fix xdata init and dongle NKRO reports

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,7 @@ inc_platform_sh68f90a = [
 ]
 
 src_platform_sh68f90a = [
+    'src/platform/sh68f90a/startup.c',
     'src/platform/sh68f90a/clock.c',
     'src/platform/sh68f90a/delay.c',
     'src/platform/sh68f90a/flash.c',

--- a/src/platform/bk3632/rf_controller.c
+++ b/src/platform/bk3632/rf_controller.c
@@ -525,16 +525,9 @@ bool rf_send_kro_report(uint8_t *buffer)
     }
     rf_tx_buf[9] = compute_byte9(active);
 
-    // rf_tx_buf[10..25] carries NKRO bit state even for 6KRO packets. Synthesize
-    // it from the 5 key bytes: keycode K sets bit (K & 7) of byte (10 + (K >> 3)).
+    // Leave the NKRO bitmap region zero: mirroring 6KRO keys here makes the dongle emit a modifier-less duplicate that breaks chords like cmd+space.
     for (int i = 10; i < 31; i++) {
         rf_tx_buf[i] = 0x00;
-    }
-    for (int j = 1; j <= 5; j++) {
-        uint8_t kc = buffer[j];
-        if (kc != 0 && (kc >> 3) < 16) {
-            rf_tx_buf[10 + (kc >> 3)] |= (uint8_t)(1u << (kc & 7));
-        }
     }
 
     rf_tx_buf[31] = checksum(rf_tx_buf, len - 1);

--- a/src/platform/sh68f90a/startup.c
+++ b/src/platform/sh68f90a/startup.c
@@ -1,0 +1,57 @@
+#include <stdint.h>
+
+// Initialized-xdata fixup for SDCC's broken XINIT copy on this part.
+//
+// SDCC's __mcs51_genXINIT copies the XINIT image into XISEG with paged
+// addressing (`mov P2,#page` / `movx @r0,a`), assembling P2 at 0xA0 per the
+// classic 8051 SFR map. The SH68F90A puts P2 at 0x98 (see sh68f90a.h), so the
+// page is never set and the copy scatters, leaving every initialized __xdata
+// variable holding power-on garbage. Only visible on a cold boot; an ISP reset
+// keeps the previous run's xdata values, hiding it.
+//
+// SDCC calls this hook from GSINIT2, before its own initialization. Redo the
+// copy here with DPTR, then return 0 so SDCC still runs its RAM clear and
+// C-level initializers. Its own genXINIT still runs, but only rewrites the same
+// bytes into unused xdata, and its RAM clear covers XSEG only
+// (0x0000..s_XISEG-1), never the XISEG bytes written here.
+//
+// Only one DPTR is available, so the loop reloads it per byte: MOVC (src) and
+// MOVX (dst) both need it.
+uint8_t __sdcc_external_startup(void) __naked
+{
+    // clang-format off
+    __asm
+        mov     r1, #l_XINIT                    ; 16-bit byte count, low
+        mov     a,  r1
+        orl     a,  #(l_XINIT >> 8)
+        jz      00003$                          ; nothing to copy
+        mov     r2, #((l_XINIT + 255) >> 8)     ; ...and its page count
+
+        mov     r3, #s_XINIT                    ; src cursor (code); #sym = low byte
+        mov     r4, #(s_XINIT >> 8)
+        mov     r5, #s_XISEG                    ; dst cursor (xdata)
+        mov     r6, #(s_XISEG >> 8)
+00001$:
+        mov     dph, r4                         ; load src, fetch one byte
+        mov     dpl, r3
+        clr     a
+        movc    a, @a+dptr
+        inc     dptr
+        mov     r3, dpl
+        mov     r4, dph
+
+        mov     dph, r6                         ; load dst, store it
+        mov     dpl, r5
+        movx    @dptr, a
+        inc     dptr
+        mov     r5, dpl
+        mov     r6, dph
+
+        djnz    r1, 00001$
+        djnz    r2, 00001$
+00003$:
+        mov     dpl, #0x00                      ; 0 = let SDCC run its normal init too
+        ret
+    __endasm;
+    // clang-format on
+}

--- a/src/platform/sh68f90a/timer2.c
+++ b/src/platform/sh68f90a/timer2.c
@@ -43,30 +43,43 @@ void timer2_scan_resume(void)
     ET2 = 1;
 }
 
-// Phase: 0 = next fire runs a matrix scan, 1 = next runs an LED substep. The
-// substep counter lives in the indicators module; when it wraps a full frame,
-// indicators_update_step returns true and we flip back to phase 0.
-static volatile uint8_t phase = 0;
+// Matrix scans are interleaved with the LED PWM subframes on this one timer. A
+// scan runs after every LED_SUBFRAMES_PER_SCAN LED subframes: 1 maximises the key
+// scan rate (a scan between every subframe, ~950 Hz — near the 1 kHz USB poll
+// ceiling), a larger value trades scan rate back for LED brightness/smoothness
+// (the backlight is blanked for the ~0.66 ms of each scan). The full LED frame
+// still takes LED_SCAN_ROWS*3 subframes; interleaving just stretches it in time.
+#define LED_SUBFRAMES_PER_SCAN 1
+
+// Phase: 0 = next fire runs a matrix scan, 1 = next runs an LED substep.
+static volatile uint8_t phase          = 0;
+static volatile uint8_t led_since_scan = 0;
 
 void timer2_interrupt_handler(void) __interrupt(_INT_TIMER2)
 {
     TF2 = 0;
 
     if (phase == 0) {
-        phase = 1;
+        phase          = 1;
+        led_since_scan = 0;
         // Short reload overflows during the scan so the first LED subframe
         // resumes the instant matrix_scan_full() returns.
         timer2_reload(T2_RELOAD_MATRIX);
         matrix_scan_full();
-
-        sleep_tick(); // advance the inactivity counter once per matrix frame
     } else {
         timer2_reload(T2_RELOAD_LED); // full 400 µs dwell
 
         indicators_pre_update();
         const bool frame_wrapped = indicators_update_step(&keyboard_state, 0);
         indicators_post_update();
+
+        // Idle timer runs off the LED frame, not the (now much faster) scan, so
+        // its cadence stays bounded regardless of LED_SUBFRAMES_PER_SCAN.
         if (frame_wrapped) {
+            sleep_tick();
+        }
+
+        if (++led_since_scan >= LED_SUBFRAMES_PER_SCAN) {
             phase = 0;
         }
     }

--- a/src/smk/sleep.c
+++ b/src/smk/sleep.c
@@ -19,9 +19,10 @@ typedef int sleep_disabled_placeholder_t;
 
 #    include <stdint.h>
 
-// Inactivity threshold, in matrix frames. sleep_tick() advances it once per
-// frame; ~41,400 frames is roughly a 6-minute idle timeout.
-#    define SLEEP_TIMEOUT 41400
+// Inactivity threshold, in LED frames. sleep_tick() runs once per LED frame
+// (~59 Hz with LED_SUBFRAMES_PER_SCAN=1); ~21,000 frames is roughly a 6-minute
+// idle timeout. Retune if the LED frame rate changes (see timer2.c).
+#    define SLEEP_TIMEOUT 21000
 
 // `inactivity` is owned by sleep_tick() during normal running; the main loop
 // only ever reads it indirectly via `sleep_requested`. Activity reaches the tick


### PR DESCRIPTION
Raises the key scan rate to ~1 kHz by scanning between LED subframes, redoes SDCC's broken initialised-xdata copy with DPTR, and leaves the NKRO bitmap zero so the dongle stops emitting modifier-less duplicates.