### PR TITLE
Remove comments that restate their code and redundant __xdata

### DIFF
--- a/src/keyboards/eyooso-z11/kb.c
+++ b/src/keyboards/eyooso-z11/kb.c
@@ -8,7 +8,7 @@ extern void indicators_next_effect();
 extern void indicators_factory_reset();
 
 // While RST_HLD (Fn+Tab) is held, pressing FCT_RST (V) factory-resets settings.
-static __xdata bool reset_mode_active;
+static bool reset_mode_active;
 
 bool kb_process_record(uint16_t keycode, bool key_pressed)
 {

--- a/src/keyboards/eyooso-z11/layouts/default/indicators.c
+++ b/src/keyboards/eyooso-z11/layouts/default/indicators.c
@@ -25,12 +25,12 @@
 _Static_assert(LED_GEOMETRY_ROWS == LED_ROWS && LED_GEOMETRY_COLS == LED_COLS, "generated LED geometry size does not match the key matrix");
 
 // Single-channel framebuffer (brightness per LED).
-static __xdata uint8_t led_fb[LED_ROWS][LED_COLS];
+static uint8_t led_fb[LED_ROWS][LED_COLS];
 
-static __xdata uint8_t led_row;
-static __xdata uint8_t led_phase;
-static __xdata uint8_t regen_row;
-static __xdata uint8_t regen_col;
+static uint8_t led_row;
+static uint8_t led_phase;
+static uint8_t regen_row;
+static uint8_t regen_col;
 
 void        indicators_pwm_enable();
 void        indicators_pwm_disable();

--- a/src/keyboards/nuphy-air60/kb.c
+++ b/src/keyboards/nuphy-air60/kb.c
@@ -28,7 +28,7 @@ typedef struct {
     user_keyboard_os_mode_t   os_mode;
 } user_keyboard_state_t;
 
-volatile __xdata user_keyboard_state_t user_keyboard_state;
+volatile user_keyboard_state_t user_keyboard_state;
 
 void kb_init()
 {
@@ -101,8 +101,8 @@ static void kb_apply_os_mode(user_keyboard_os_mode_t mode)
 
 void kb_update_switches()
 {
-    static __xdata uint16_t conn_debounce;
-    static __xdata uint16_t os_debounce;
+    static uint16_t conn_debounce;
+    static uint16_t os_debounce;
 
     const uint8_t raw_conn = CONN_MODE_SWITCH;
     if (raw_conn == user_keyboard_state.conn_mode) {
@@ -157,10 +157,10 @@ extern void indicators_battery_off();
 
 // While UL_MODE (the "?" key on the Fn layer) is held, the RGB_* chords adjust the
 // underglow instead of the main backlight. Held in xdata to spare internal RAM.
-static __xdata bool ul_mode_active;
+static bool ul_mode_active;
 
 // While RST_HLD (Fn+Tab) is held, pressing FCT_RST (V) factory-resets settings.
-static __xdata bool reset_mode_active;
+static bool reset_mode_active;
 
 #ifdef RF_ENABLED
 // Track a LNK_BT* / LNK_24G being held so kb_update can fire the pairing
@@ -171,9 +171,9 @@ static __xdata bool reset_mode_active;
 // per FN-key press and don't periodically re-fire: re-firing rotates the
 // BK3632's BLE advertising MAC and disrupts hosts mid-SMP.
 #    define LINK_PAIRING_HOLD_TICKS 60000
-static __xdata uint16_t link_hold_ticks    = 0;
-static __xdata uint16_t link_hold_keycode  = 0;
-static __xdata bool     link_pairing_armed = false;
+static uint16_t link_hold_ticks    = 0;
+static uint16_t link_hold_keycode  = 0;
+static bool     link_pairing_armed = false;
 #endif
 
 bool kb_process_record(uint16_t keycode, bool key_pressed)
@@ -341,7 +341,7 @@ void kb_send_extra(__xdata report_extra_t *report)
     }
 }
 
-__xdata uint16_t ticks = 0;
+uint16_t ticks = 0;
 
 void kb_update()
 {

--- a/src/keyboards/nuphy-air60/kb.c
+++ b/src/keyboards/nuphy-air60/kb.c
@@ -60,64 +60,64 @@ void kb_init()
 // during a slide.
 #define SLIDER_DEBOUNCE_ITERS 256
 
+static void kb_apply_conn_mode(user_keyboard_conn_mode_t mode)
+{
+    user_keyboard_state.conn_mode = mode;
+
+    switch (mode) {
+        case KEYBOARD_CONN_MODE_USB:
+            dprintf("USB_MODE\r\n");
+#ifdef RF_ENABLED
+            // The BK3632 keeps forwarding keys wirelessly until told the host
+            // is wired.
+            rf_apply_usb_mode();
+#endif
+            break;
+        case KEYBOARD_CONN_MODE_RF:
+            dprintf("RF_MODE\r\n");
+#ifdef RF_ENABLED
+            rf_set_link((rf_mode_t)user_settings.rf_link);
+            // Queue a clean baseline release so the host sees zero keys held
+            // after the transition; the next matrix scan re-detects whatever is
+            // actually down.
+            rf_kbd_lazy_state_init();
+#endif
+            break;
+    }
+}
+
+static void kb_apply_os_mode(user_keyboard_os_mode_t mode)
+{
+    const bool is_mac = (mode == KEYBOARD_OS_MODE_MAC);
+
+    user_keyboard_state.os_mode = mode;
+    set_default_layer(layout_os_base_layer(is_mac));
+
+    dprintf(is_mac ? "MAC_MODE\r\n" : "WIN_MODE\r\n");
+#ifdef RF_ENABLED
+    rf_set_mac_mode_compat(is_mac);
+#endif
+}
+
 void kb_update_switches()
 {
     static __xdata uint16_t conn_debounce;
     static __xdata uint16_t os_debounce;
 
-    // CONN_MODE_SWITCH — debounce + commit + transition
     const uint8_t raw_conn = CONN_MODE_SWITCH;
     if (raw_conn == user_keyboard_state.conn_mode) {
         conn_debounce = 0;
     } else if (++conn_debounce >= SLIDER_DEBOUNCE_ITERS) {
-        conn_debounce                 = 0;
-        user_keyboard_state.conn_mode = raw_conn;
-        switch (user_keyboard_state.conn_mode) {
-            case KEYBOARD_CONN_MODE_USB:
-                dprintf("USB_MODE\r\n");
-#ifdef RF_ENABLED
-                // Tell the BK3632 the host is now wired so it stops
-                // trying to forward keys wirelessly.
-                rf_apply_usb_mode();
-#endif
-                break;
-            case KEYBOARD_CONN_MODE_RF:
-                dprintf("RF_MODE\r\n");
-#ifdef RF_ENABLED
-                // Re-prime the BK3632 on the saved link slot.
-                rf_set_link((rf_mode_t)user_settings.rf_link);
-                // Lazy-init: queue a clean baseline release so the host
-                // sees zero keys held after the transition, then the
-                // next matrix scan re-detects whatever's actually down.
-                rf_kbd_lazy_state_init();
-#endif
-                break;
-        }
+        conn_debounce = 0;
+        kb_apply_conn_mode((user_keyboard_conn_mode_t)raw_conn);
     }
 
-    // OS_MODE_SWITCH — debounce + commit + Mac-compat byte9 update
     const uint8_t raw_os = OS_MODE_SWITCH;
     if (raw_os == user_keyboard_state.os_mode) {
         os_debounce = 0;
     } else if (++os_debounce >= SLIDER_DEBOUNCE_ITERS) {
-        os_debounce                 = 0;
-        user_keyboard_state.os_mode = raw_os;
-        // Switch the base keymap (Win/Mac modifier layout) to match the slider.
-        set_default_layer(layout_os_base_layer(user_keyboard_state.os_mode == KEYBOARD_OS_MODE_MAC));
-        switch (user_keyboard_state.os_mode) {
-            case KEYBOARD_OS_MODE_MAC:
-                dprintf("MAC_MODE\r\n");
-#ifdef RF_ENABLED
-                rf_set_mac_mode_compat(true);
-#endif
-                break;
-            case KEYBOARD_OS_MODE_WIN:
-                dprintf("WIN_MODE\r\n");
-#ifdef RF_ENABLED
-                rf_set_mac_mode_compat(false);
-#endif
-                break;
-        }
+        os_debounce = 0;
+        kb_apply_os_mode((user_keyboard_os_mode_t)raw_os);
     }
 }
 
@@ -267,12 +267,10 @@ bool kb_process_record(uint16_t keycode, bool key_pressed)
                     keyboard_state.rf_link   = (uint8_t)mode;
                     keyboard_state.connected = 1;
                     keyboard_state.paired    = 1;
-                    // Arm long-press → pairing.
-                    link_hold_keycode  = keycode;
-                    link_hold_ticks    = 0;
-                    link_pairing_armed = true;
+                    link_hold_keycode        = keycode;
+                    link_hold_ticks          = 0;
+                    link_pairing_armed       = true;
                 } else {
-                    // Release — clear long-press tracker if it's for this key.
                     if (link_hold_keycode == keycode) {
                         link_hold_keycode  = 0;
                         link_pairing_armed = false;

--- a/src/keyboards/nuphy-air60/layouts/default/indicators.c
+++ b/src/keyboards/nuphy-air60/layouts/default/indicators.c
@@ -142,7 +142,8 @@ void indicators_battery_off()
     settings_mark_dirty();
 }
 
-// Factory reset: restore defaults and persist them so the next boot loads them too.
+// Persist the defaults too, so the next boot loads them rather than the
+// record we just replaced.
 void indicators_factory_reset()
 {
     indicators_apply_defaults();

--- a/src/keyboards/nuphy-air60/layouts/default/indicators.c
+++ b/src/keyboards/nuphy-air60/layouts/default/indicators.c
@@ -56,48 +56,48 @@
 _Static_assert(LED_GEOMETRY_ROWS == LED_ROWS && LED_GEOMETRY_COLS == LED_COLS, "generated LED geometry size does not match the key matrix");
 
 // Per-LED RGB framebuffer for the main key matrix, indexed [row][color][col].
-static __xdata uint8_t led_fb[LED_ROWS][3][LED_COLS];
+static uint8_t led_fb[LED_ROWS][3][LED_COLS];
 
 // Separate framebuffer for the underglow ("user") LEDs, since they animate
 // independently of the main backlight.
-static __xdata uint8_t led_ul_fb[3][LED_COLS];
+static uint8_t led_ul_fb[3][LED_COLS];
 
 // LED scan cursor, advanced one (row,color) substep per PWM ISR. Decoupled from
 // the key-matrix column scan (current_step).
-static __xdata uint8_t led_row;
-static __xdata uint8_t led_color;
+static uint8_t led_row;
+static uint8_t led_color;
 
 // Animation state. The framebuffers are regenerated one LED at a time in the
 // main loop (indicators_render → led_regen_one) cycling through the main rows
 // then the underglow row (regen_row/regen_col). led_phase / ul_phase shift
 // their respective rainbow on a fixed cadence driven by anim_ctr in the scan
 // ISR — not by the (free-running) render cursor.
-static __xdata uint8_t led_phase;
-static __xdata uint8_t ul_phase;
-static __xdata uint8_t regen_row;
-static __xdata uint8_t regen_col;
+static uint8_t led_phase;
+static uint8_t ul_phase;
+static uint8_t regen_row;
+static uint8_t regen_col;
 
 // Animation clock, advanced one step per scanned subframe in the ISR. Drives
 // the phase / status-counter cadence independently of how fast the main-loop
 // render walks the framebuffer.
-static __xdata uint8_t anim_ctr;
+static uint8_t anim_ctr;
 
 // Set by the ISR when the phase advances; the main-loop render regenerates a
 // whole consistent frame on each set and clears it. Decouples the frame rate
 // from the (very uneven, in wireless mode) main-loop iteration rate — without
 // it a slow loop refreshes only a cell or two per pass and the animation crawls
 // in line-by-line, with different parts of the frame at different phases.
-static volatile __xdata bool render_dirty;
+static volatile bool render_dirty;
 
 // FN+[ momentary battery indicator: counts down once per UL sweep; while non-zero
 // the right-side UL LEDs show the battery colour regardless of the persistent
 // `user_settings.battery_indicator_on` flag.
-static __xdata uint8_t battery_flash_sweeps;
+static uint8_t battery_flash_sweeps;
 
 // Free-running counter incremented once per UL sweep (~73 Hz). Used to drive
 // the unpaired (fast blink) / disconnected (slow breath) status indicator
 // on the left-side UL LEDs.
-static __xdata uint8_t status_pulse_counter;
+static uint8_t status_pulse_counter;
 
 // Quarter-sine LUT used to drive the disconnected "breathing" effect. 32
 // entries, 0..255 amplitude over 0..π/2. Mirrored at runtime to produce a

--- a/src/keyboards/nuphy-air60/user_sleep.c
+++ b/src/keyboards/nuphy-air60/user_sleep.c
@@ -94,7 +94,6 @@ void user_sleep_wake(void)
     P0CR |= RF_BB_SPI_MOT_P0_5;
     RF_BB_SPI_MOT = 0;
 
-    // Restore the normal operating GPIO configuration.
     user_gpio_init();
 }
 

--- a/src/platform/bb_spi.c
+++ b/src/platform/bb_spi.c
@@ -96,12 +96,10 @@ uint8_t bb_spi_xfer_byte(uint8_t data)
     for (uint8_t i = 0; i < 8; i++) {
         recv = recv << 1;
 
-        // SCK low
         RF_BB_SPI_SCK = 0;
         P4CR |= _P4_7;
         RF_BB_SPI_SCK = 0;
 
-        // MOSI (open-drain)
         if (data & (1 << 7)) {
             P0CR &= (uint8_t)~_P0_7; // MOSI -> input, pull-up to high
             RF_BB_SPI_MOSI = 1;
@@ -115,7 +113,6 @@ uint8_t bb_spi_xfer_byte(uint8_t data)
             recv |= 0x01;
         }
 
-        // SCK release high (input + pull-up)
         P4CR &= (uint8_t)~_P4_7;
         RF_BB_SPI_SCK = 1;
 

--- a/src/platform/bk3632/rf_controller.c
+++ b/src/platform/bk3632/rf_controller.c
@@ -22,17 +22,17 @@ typedef enum {
 static const __code char rf_bt5_name[] = "SMK BT5.0";
 static const __code char rf_bt3_name[] = "SMK BT3.0";
 
-__xdata uint8_t rf_tx_buf[32];
+uint8_t rf_tx_buf[32];
 
-static __xdata uint8_t kro_prev_active;
-static __xdata uint8_t blanking_pending;
-static __xdata bool    blanking_active;
+static uint8_t kro_prev_active;
+static uint8_t blanking_pending;
+static bool    blanking_active;
 
 // byte9 override flags. mac_mode_compat forces byte9 to 0 ("active"); macOS
 // needs every packet flagged active, else the BK3632 dedupes idle packets and
 // the host misses releases. byte9_disable skips only the idle branch.
-static __xdata bool mac_mode_compat;
-static __xdata bool byte9_disable;
+static bool mac_mode_compat;
+static bool byte9_disable;
 
 void rf_set_mac_mode_compat(bool is_mac)
 {
@@ -137,14 +137,14 @@ void rf_factory_reset_bonds(void)
     delay_ms(200);
 }
 
-__xdata uint8_t kro6buffer[6];
+uint8_t kro6buffer[6];
 
 // Send queue. rf_send_report stashes the 6KRO snapshot here and sends
 // immediately; if the send fails (unresponsive after RF_SEND_MAX_ATTEMPTS),
 // rf_pending stays set and rf_send_pending_flush retries from the same buffer.
 // Each new matrix event overwrites the buffer, so retries converge to current.
-static __xdata uint8_t rf_pending_buf[6];
-static __xdata bool    rf_pending;
+static uint8_t rf_pending_buf[6];
+static bool    rf_pending;
 
 void rf_send_report(__xdata report_keyboard_t *report)
 {
@@ -249,11 +249,11 @@ bool rf_update_keyboard_state(keyboard_state_t *keyboard)
 // Link mode last commanded by us — the re-assert target. keyboard->rf_link
 // can't serve here: it mirrors what the BK3632 *reports*, and the point is to
 // correct the chip when the two disagree.
-static __xdata uint8_t  commanded_link       = RF_MODE_2_4G;
-static __xdata uint16_t pairing_window_polls = 0;
+static uint8_t  commanded_link       = RF_MODE_2_4G;
+static uint16_t pairing_window_polls = 0;
 
-static __xdata uint16_t supervisor_ticks      = 0;
-static __xdata uint8_t  supervisor_was_paired = 0;
+static uint16_t supervisor_ticks      = 0;
+static uint8_t  supervisor_was_paired = 0;
 
 void rf_link_supervisor(keyboard_state_t *keyboard)
 {
@@ -308,7 +308,7 @@ void rf_apply_usb_mode(void)
     rf_cmd_06(1);
 }
 
-static __xdata bool lazy_init_pending;
+static bool lazy_init_pending;
 
 void rf_kbd_lazy_state_init(void)
 {
@@ -332,9 +332,9 @@ void rf_blanking_tick(void)
     // decrement). pending == 6,4,2 → phantom (HID key 0x01 down).
     // pending == 5,3,1 → blank (all-zero release).
     //   buffer layout: [mods, key0, key1, key2, key3, key4]
-    static __xdata uint8_t phantom_buf[6] = {0, 0x01, 0, 0, 0, 0};
-    static __xdata uint8_t blank_buf[6]   = {0, 0, 0, 0, 0, 0};
-    uint8_t               *buf            = ((blanking_pending & 1) == 0) ? phantom_buf : blank_buf;
+    static uint8_t phantom_buf[6] = {0, 0x01, 0, 0, 0, 0};
+    static uint8_t blank_buf[6]   = {0, 0, 0, 0, 0, 0};
+    uint8_t       *buf            = ((blanking_pending & 1) == 0) ? phantom_buf : blank_buf;
 
     blanking_pending--;
 
@@ -347,8 +347,8 @@ void rf_blanking_tick(void)
 
 // Module-static scratch for rf_set_link_pairing — keeps the loop's locals out
 // of internal RAM so SDCC's OSEG packer doesn't run out of slots.
-static __xdata uint8_t pairing_status_bytes[2];
-static __xdata uint8_t pairing_paired_now;
+static uint8_t pairing_status_bytes[2];
+static uint8_t pairing_paired_now;
 
 void rf_set_link_pairing(rf_mode_t link, __xdata keyboard_state_t *keyboard)
 {
@@ -497,7 +497,7 @@ bool rf_send_kro_report(uint8_t *buffer)
 
     // On pending lazy init, override the buffer with an all-zero baseline so
     // the BK3632 gets a clean release; held keys re-detect on the next sweep.
-    static __xdata uint8_t empty_buf[6] = {0, 0, 0, 0, 0, 0};
+    static uint8_t empty_buf[6] = {0, 0, 0, 0, 0, 0};
     if (lazy_init_pending) {
         lazy_init_pending = false;
         buffer            = empty_buf;

--- a/src/platform/sh68f90a/clock.c
+++ b/src/platform/sh68f90a/clock.c
@@ -3,7 +3,6 @@
 #include "delay.h"
 #include "watchdog.h"
 
-// Set up HRCCLK/PLL and use it as SYSCLK.
 void clock_init()
 {
     CLKCON = _HFON;

--- a/src/platform/sh68f90a/power.c
+++ b/src/platform/sh68f90a/power.c
@@ -17,7 +17,7 @@
 // Set when an INT4 edge woke the core, cleared before each Power-Down. Remote
 // wakeup is only signalled for an INT4 wake, never when the host resumed the bus
 // itself.
-static volatile __xdata uint8_t int4_woke;
+static volatile uint8_t int4_woke;
 
 static void usb_park(powerdown_mode_t mode)
 {

--- a/src/platform/sh68f90a/stack.c
+++ b/src/platform/sh68f90a/stack.c
@@ -40,8 +40,8 @@ static uint8_t stack_peak(void)
 
 void stack_task(void)
 {
-    static __xdata uint8_t reported = 0;
-    static __xdata uint8_t throttle = 0;
+    static uint8_t reported = 0;
+    static uint8_t throttle = 0;
 
     if (++throttle != 0) {
         return; // ~once every 256 main-loop iterations

--- a/src/platform/sh68f90a/usb.c
+++ b/src/platform/sh68f90a/usb.c
@@ -338,25 +338,25 @@ static void usb_hid_get_protocol_handler(struct usb_req_setup *req);
 /**
  * 0.5KB of general purpose scratch RAM.
  */
-__xdata uint8_t scratch[512];
+uint8_t scratch[512];
 
 uint16_t ep0_xfer_bytes_left;
 uint8_t *ep0_xfer_src;
 
 // usb state
-usb_device_state_t __xdata usb_device_state;
-uint8_t __xdata            received_usb_addr;
-uint8_t __xdata            active_configuration;
-uint8_t __xdata            interface0_protocol;
-uint8_t __xdata            interface1_protocol;
+usb_device_state_t usb_device_state;
+uint8_t            received_usb_addr;
+uint8_t            active_configuration;
+uint8_t            interface0_protocol;
+uint8_t            interface1_protocol;
 // Host-controlled remote-wakeup enable, per SET/CLEAR_FEATURE.
 static __bit usb_remote_wakeup;
 // Set when the host suspends the bus (SUSPIF), cleared on the next SOF or bus
 // reset. The sleep feature only enters USB-suspend Power-Down once the host has
 // parked the bus itself — self-suspending mid-poll would break the link.
-__bit                   usb_suspended;
-uint8_t __xdata         idle_time;
-usb_ep0_state_t __xdata usb_ep0_state;
+__bit           usb_suspended;
+uint8_t         idle_time;
+usb_ep0_state_t usb_ep0_state;
 
 // Enumeration progress, in 1 ms SOF ticks. Reloaded on every SETUP and
 // decremented on every SOF, so it stays above zero for as long as the host is
@@ -367,8 +367,8 @@ usb_ep0_state_t __xdata usb_ep0_state;
 #define ENUM_NO_HOST_MS 500
 #define ENUM_GIVE_UP_MS 4000
 
-static __xdata uint16_t enum_quiet_ticks;
-static __xdata bool     enum_seen;
+static uint16_t enum_quiet_ticks;
+static bool     enum_seen;
 
 void usb_init()
 {

--- a/src/smk/console.c
+++ b/src/smk/console.c
@@ -97,13 +97,13 @@ void console_printf(const __code char *fmt, ...) __reentrant
 #    define CONSOLE_BUF_SIZE 128 // must stay a power of two
 #    define CONSOLE_BUF_MASK (CONSOLE_BUF_SIZE - 1)
 
-static __xdata unsigned char    console_buf[CONSOLE_BUF_SIZE];
-static volatile __xdata uint8_t console_head; // producer (console_putc)
-static volatile __xdata uint8_t console_tail; // consumer (console_task)
+static unsigned char    console_buf[CONSOLE_BUF_SIZE];
+static volatile uint8_t console_head; // producer (console_putc)
+static volatile uint8_t console_tail; // consumer (console_task)
 
 // Set once the host tool has handshaked; cleared when the link drops, so a
 // re-attach must handshake again and re-flushes whatever has queued.
-static __xdata uint8_t console_attached;
+static uint8_t console_attached;
 
 void console_notify_attached(void)
 {
@@ -127,7 +127,7 @@ void console_putc(unsigned char c)
 
 void console_task(void)
 {
-    static __xdata unsigned char report[CONSOLE_REPORT_SIZE];
+    static unsigned char report[CONSOLE_REPORT_SIZE];
 
     if (!usb_is_configured()) {
         console_attached = 0; // require a fresh handshake once the link is back

--- a/src/smk/console.c
+++ b/src/smk/console.c
@@ -125,7 +125,6 @@ void console_putc(unsigned char c)
     }
 }
 
-// Drains buffered bytes to the host as one console HID report per call.
 void console_task(void)
 {
     static __xdata unsigned char report[CONSOLE_REPORT_SIZE];

--- a/src/smk/host.c
+++ b/src/smk/host.c
@@ -5,10 +5,10 @@
 
 // System and consumer usages are level-triggered: the host holds the last usage
 // until we send a different one, so a repeat send is redundant traffic.
-static __xdata uint16_t last_system_usage;
-static __xdata uint16_t last_consumer_usage;
+static uint16_t last_system_usage;
+static uint16_t last_consumer_usage;
 
-static __xdata report_extra_t extra_report;
+static report_extra_t extra_report;
 
 bool host_nkro_active(void)
 {

--- a/src/smk/keyboard.c
+++ b/src/smk/keyboard.c
@@ -1,9 +1,9 @@
 #include "keyboard.h"
 #include "debug.h"
 
-volatile __xdata keyboard_state_t keyboard_state;
+volatile keyboard_state_t keyboard_state;
 
-__xdata keymap_config_t keymap_config;
+keymap_config_t keymap_config;
 
 void keyboard_init(void)
 {

--- a/src/smk/keyboard.h
+++ b/src/smk/keyboard.h
@@ -15,8 +15,8 @@ typedef struct {
     uint8_t nkro;
 } keymap_config_t;
 
-extern volatile __xdata keyboard_state_t keyboard_state;
-extern __xdata keymap_config_t           keymap_config;
+extern volatile keyboard_state_t keyboard_state;
+extern keymap_config_t           keymap_config;
 
 void keyboard_init(void);
 

--- a/src/smk/matrix.c
+++ b/src/smk/matrix.c
@@ -46,8 +46,6 @@ void set_default_layer(uint8_t layer)
     default_layer = layer;
 }
 
-// Resolve what a key means right now: the base layer, unless a momentary layer
-// is held and defines something other than KC_TRANSPARENT there.
 static uint16_t resolve_keycode(uint16_t base, uint8_t row, uint8_t col)
 {
     if (!action_layer) {

--- a/src/smk/matrix.c
+++ b/src/smk/matrix.c
@@ -15,8 +15,8 @@
 
 typedef uint8_t matrix_col_t;
 
-__xdata matrix_col_t matrix[MATRIX_COLS];
-__xdata matrix_col_t matrix_previous[MATRIX_COLS];
+matrix_col_t matrix[MATRIX_COLS];
+matrix_col_t matrix_previous[MATRIX_COLS];
 
 // Set by matrix_scan_full() each time a full column sweep completes; cleared by
 // matrix_task() after it has diffed the new sample against the previous one.
@@ -27,7 +27,7 @@ uint8_t action_layer;
 
 // Base layer the matrix resolves keys against when no momentary (MO) layer is
 // held. Defaults to 0; a keyboard can retarget it at runtime.
-__xdata uint8_t default_layer;
+uint8_t default_layer;
 
 void matrix_init()
 {

--- a/src/smk/report.c
+++ b/src/smk/report.c
@@ -40,7 +40,6 @@ void send_6kro_report()
     keyboard_report.mods = real_mods;
     keyboard_report.mods |= weak_mods;
 
-    // Only send the report when something changed.
     if (memcmp(&keyboard_report, &last_report, sizeof(report_keyboard_t)) != 0) {
         // Byte loop, not library memcpy: memcpy is non-reentrant here, and an
         // interrupt-driven copy can preempt this one and corrupt it. Keeping the
@@ -59,7 +58,6 @@ void send_nkro_report()
     nkro_report.mods      = real_mods;
     nkro_report.mods |= weak_mods;
 
-    // Only send the report when something changed.
     if (memcmp(&nkro_report, &last_nkro_report, sizeof(report_nkro_t)) != 0) {
         // Byte loop, not library memcpy — see send_6kro_report.
         for (uint8_t i = 0; i < NKRO_REPORT_SIZE; i++) {
@@ -259,7 +257,6 @@ uint8_t biton(uint8_t bits)
     return n;
 }
 
-/* keycode to system usage */
 uint16_t keycode_to_system(uint8_t key)
 {
     switch (key) {
@@ -274,7 +271,6 @@ uint16_t keycode_to_system(uint8_t key)
     }
 }
 
-/* keycode to consumer usage */
 uint16_t keycode_to_consumer(uint8_t key)
 {
     switch (key) {

--- a/src/smk/report.c
+++ b/src/smk/report.c
@@ -9,11 +9,11 @@
 static uint8_t real_mods = 0;
 static uint8_t weak_mods = 0;
 
-__xdata report_keyboard_t keyboard_report;
-__xdata report_keyboard_t last_report;
+report_keyboard_t keyboard_report;
+report_keyboard_t last_report;
 
-__xdata report_nkro_t nkro_report;
-__xdata report_nkro_t last_nkro_report;
+report_nkro_t nkro_report;
+report_nkro_t last_nkro_report;
 
 uint8_t biton(uint8_t bits);
 

--- a/src/smk/report.h
+++ b/src/smk/report.h
@@ -63,8 +63,8 @@ typedef union {
     };
 } report_extra_t;
 
-extern __xdata report_keyboard_t keyboard_report;
-extern __xdata report_nkro_t     nkro_report;
+extern report_keyboard_t keyboard_report;
+extern report_nkro_t     nkro_report;
 
 void send_keyboard_report();
 

--- a/src/smk/settings.c
+++ b/src/smk/settings.c
@@ -8,12 +8,12 @@
 // storage sector the build fails here instead of corrupting adjacent storage.
 _Static_assert(sizeof(user_settings_t) + 4u <= 512u, "user_settings_t too large for the settings sector");
 
-__xdata user_settings_t user_settings;
+user_settings_t user_settings;
 
 // Deferred-save dirty flag. Handlers set it and return; settings_task() flushes
 // and clears. Multiple marks between flushes coalesce into one write, so a fast
 // brightness ramp produces a single persist instead of one per step.
-static __xdata bool settings_dirty;
+static bool settings_dirty;
 
 bool settings_load(void)
 {

--- a/src/smk/settings.h
+++ b/src/smk/settings.h
@@ -25,7 +25,7 @@ typedef struct {
     uint8_t rf_link;
 } user_settings_t;
 
-extern __xdata user_settings_t user_settings;
+extern user_settings_t user_settings;
 
 // Overwrites `user_settings` with the persisted values if a valid record
 // exists. Returns true on success; on false the caller is responsible for

--- a/src/smk/settings.h
+++ b/src/smk/settings.h
@@ -9,7 +9,6 @@
 // small (it shares one storage sector) and note that a firmware reflash resets
 // it to the defaults the caller seeds before settings_load().
 typedef struct {
-    // main backlight
     uint8_t led_effect;     // selected backlight effect (or "off")
     uint8_t led_brightness; // 0 (dark) .. 255 (full)
     uint8_t led_speed;      // animation phase increment (1 = slowest)

--- a/src/smk/sleep.c
+++ b/src/smk/sleep.c
@@ -29,9 +29,9 @@ typedef int sleep_disabled_placeholder_t;
 // indirectly via `sleep_requested`. Activity reaches the tick through the
 // single-byte `activity_seen` flag, so there is no read-modify-write race on the
 // 16-bit counter across contexts.
-static volatile __xdata uint16_t inactivity;
-static volatile __xdata uint8_t  activity_seen;
-static volatile __xdata uint8_t  sleep_requested;
+static volatile uint16_t inactivity;
+static volatile uint8_t  activity_seen;
+static volatile uint8_t  sleep_requested;
 
 void sleep_init(void)
 {
@@ -86,7 +86,7 @@ static bool sleep_due(user_sleep_mode_t mode)
 
 static void rf_resync_after_wake(void)
 {
-    static __xdata uint8_t tries;
+    static uint8_t tries;
 
     for (tries = RF_RESYNC_TRIES; tries > 0; tries--) {
         rf_wake_nudge();

--- a/src/smk/tick.h
+++ b/src/smk/tick.h
@@ -9,7 +9,7 @@
 
 void tick_init(void);
 
-// Run whichever slot is due. Called from the platform's tick interrupt.
+// Called from the platform's tick interrupt.
 void tick_dispatch(void);
 
 // Hold the matrix sweep and the backlight still without stopping time. Needed


### PR DESCRIPTION
Drops comments a reader could recover from the adjacent line and __xdata on object declarations that --model-large already implies, leaving pointer qualifiers intact; firmware is byte-identical.