### PR TITLE
Add a HID debug console sink and host reader tool

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,6 +124,14 @@ endif
 if get_option('buildtype') == 'debug'
     cc_base_args += '-DDEBUG=1'
     cc_base_args += '--debug'   # emit SDCC .cdb for source-level tests (tests/sim.py)
+
+    debug_sink = get_option('debug_sink')
+    if debug_sink == 'console' or debug_sink == 'both'
+        cc_base_args += '-DDEBUG_SINK_CONSOLE=1'
+    endif
+    if debug_sink == 'uart' or debug_sink == 'both'
+        cc_base_args += '-DDEBUG_SINK_UART=1'
+    endif
 endif
 
 sdar_args = ['-rc']
@@ -139,6 +147,16 @@ sinowisp = find_program('sinowisp', required : true)
 host_cc = find_program('cc', 'gcc', required : true)
 gen_led_geometry = join_paths(meson.current_build_dir(), 'led_geometry_gen')
 run_command(host_cc, '-O2', '-o', gen_led_geometry, join_paths(meson.current_source_dir(), 'utils/led_geometry_gen.c'), check : true)
+
+# Host-side debug tool: prints SMK's HID console output (report id 7) from
+# DEBUG builds. Built with the build-machine compiler, independent of the
+# sdcc firmware cross-build above.
+executable(
+    'smk-console',
+    'tools/smk-console.c',
+    native : true,
+    install : false,
+)
 
 dir_base = meson.current_source_dir()
 

--- a/meson.options
+++ b/meson.options
@@ -1,1 +1,3 @@
 option('nkro', type : 'feature', value : 'enabled', description: 'NKRO support')
+option('debug_sink', type : 'combo', choices : ['console', 'uart', 'both'], value : 'console',
+       description: 'Where dprintf output goes in debug builds: HID console only (default), UART only, or both. UART has a blocking busy-wait per byte (uart_putc), so picking it can stall the main loop while the TX shift register drains.')

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,9 @@
 #include "watchdog.h"
 #include "delay.h"
 #include "isp.h"
-#include "uart.h"
+#ifdef DEBUG_SINK_UART
+#    include "uart.h"
+#endif
 #include "usb.h"
 #include "debug.h"
 #include "matrix.h"
@@ -11,7 +13,6 @@
 #include "keyboard.h"
 #include "user_init.h"
 #include "indicators.h"
-#include "uart.h"
 #include "kb.h"
 #include "console.h"
 #include "stack.h"
@@ -27,7 +28,7 @@ void init()
 {
     ldo_init();
     clock_init();
-#if DEBUG == 1
+#ifdef DEBUG_SINK_UART
     uart_init();
 #endif
 

--- a/src/platform/sh68f90a/uart.c
+++ b/src/platform/sh68f90a/uart.c
@@ -4,38 +4,40 @@
 #include "console.h"
 #include <stdint.h>
 
-#define UART_BPS   57600
-#define UART_MODE  1
-#define UART_RX_EN 0
+#ifdef DEBUG_SINK_UART
 
-#if (UART_MODE == 1 || UART_MODE == 3)
-#    ifndef FREQ_SYS
-#        error FREQ_SYS must be defined
-#    endif
+#    define UART_BPS   57600
+#    define UART_MODE  1
+#    define UART_RX_EN 0
+
+#    if (UART_MODE == 1 || UART_MODE == 3)
+#        ifndef FREQ_SYS
+#            error FREQ_SYS must be defined
+#        endif
 
 // Mode 1/3 baud rate (datasheet §8.5.3):
 //   BaudRate = Fsys / (16 * (32768 - SBRT) + BFINE)
 // SBRT is a 15-bit value stored in SBRTH[6:0]:SBRTL[7:0]; SBRTH[7] is SBRTEN.
-#    define SBRT_INT (FREQ_SYS / 16 / UART_BPS)
-#    define SBRT_S   (32768 - SBRT_INT)
-#    define SFINE_S  ((FREQ_SYS / UART_BPS) - (16 * SBRT_INT))
+#        define SBRT_INT (FREQ_SYS / 16 / UART_BPS)
+#        define SBRT_S   (32768 - SBRT_INT)
+#        define SFINE_S  ((FREQ_SYS / UART_BPS) - (16 * SBRT_INT))
 
-#    define UART_RESULT_BPS (FREQ_SYS / (16 * SBRT_INT + SFINE_S))
-#    define UART_BPS_ERROR  ((UART_RESULT_BPS - UART_BPS) * 100 / UART_BPS)
-#    if UART_BPS_ERROR >= 5 || UART_BPS_ERROR <= -5
-#        error "UART baudrate error >= 5%, try a different UART_BPS"
+#        define UART_RESULT_BPS (FREQ_SYS / (16 * SBRT_INT + SFINE_S))
+#        define UART_BPS_ERROR  ((UART_RESULT_BPS - UART_BPS) * 100 / UART_BPS)
+#        if UART_BPS_ERROR >= 5 || UART_BPS_ERROR <= -5
+#            error "UART baudrate error >= 5%, try a different UART_BPS"
+#        endif
+#    else
+#        define SBRT_S  0
+#        define SFINE_S 0
 #    endif
-#else
-#    define SBRT_S  0
-#    define SFINE_S 0
-#endif
 
-#define SCON_INIT  ((UART_MODE << 6) | (UART_RX_EN << 4))
-#define SBRT_INIT  (uint16_t)((_SBRTEN << 8) | SBRT_S)
-#define SFINE_INIT (SFINE_S)
+#    define SCON_INIT  ((UART_MODE << 6) | (UART_RX_EN << 4))
+#    define SBRT_INIT  (uint16_t)((_SBRTEN << 8) | SBRT_S)
+#    define SFINE_INIT (SFINE_S)
 
-#define UART_ISR_ENABLE()  (IEN1 |= _ES0)
-#define UART_ISR_DISABLE() (IEN1 &= ~_ES0)
+#    define UART_ISR_ENABLE()  (IEN1 |= _ES0)
+#    define UART_ISR_DISABLE() (IEN1 &= ~_ES0)
 
 // Compile-time verification against datasheet §8.5.3.
 // Mode 1, SBRT (15-bit) is in valid range [0, 32767].
@@ -43,12 +45,12 @@ _Static_assert(SBRT_S >= 0 && SBRT_S < 32768, "SBRT out of 15-bit range");
 _Static_assert(SFINE_S >= 0 && SFINE_S < 16, "SFINE must be in [0, 15]");
 // Datasheet's worked example: Fsys=8MHz, baud=115200 -> SBRT=32764, BFINE=5,
 // effective baud 115942 (+0.64%). Verify our formulas reproduce it.
-#define _DS_SBRT(fsys, baud)  (32768 - ((fsys) / 16 / (baud)))
-#define _DS_SFINE(fsys, baud) (((fsys) / (baud)) - 16 * ((fsys) / 16 / (baud)))
+#    define _DS_SBRT(fsys, baud)  (32768 - ((fsys) / 16 / (baud)))
+#    define _DS_SFINE(fsys, baud) (((fsys) / (baud)) - 16 * ((fsys) / 16 / (baud)))
 _Static_assert(_DS_SBRT(8000000, 115200) == 32764, "SBRT formula diverges from datasheet example");
 _Static_assert(_DS_SFINE(8000000, 115200) == 5, "SFINE formula diverges from datasheet example");
-#undef _DS_SBRT
-#undef _DS_SFINE
+#    undef _DS_SBRT
+#    undef _DS_SFINE
 
 volatile static __bit uart_tx_busy;
 
@@ -106,10 +108,15 @@ void uart_interrupt_handler() __interrupt(_INT_EUART0)
     UART_ISR_ENABLE();
 }
 
+#endif // DEBUG_SINK_UART
+
 void putchar(int c)
 {
-    uart_putc(c);
-#if DEBUG == 1
-    console_putc(c);
+#ifdef DEBUG_SINK_UART
+    uart_putc((unsigned char)c);
 #endif
+#ifdef DEBUG_SINK_CONSOLE
+    console_putc((unsigned char)c);
+#endif
+    (void)c;
 }

--- a/src/smk/console.c
+++ b/src/smk/console.c
@@ -3,9 +3,94 @@
 #if DEBUG == 1
 
 #    include "report.h"
-#    include "usb.h"     // usb_is_configured(), EP2 buffer/SFRs via sh68f90a.h
-#    include "usbregs.h" // SET_EP2_CNT, SET_EP2_IN_RDY
+#    include "usb.h"
+#    include "usbregs.h"
 #    include <stdint.h>
+#    include <stdarg.h>
+
+static void console_emit_num(uint16_t val, uint8_t base, uint8_t width, char pad, uint8_t upper) __reentrant
+{
+    char    buf[5]; // 16-bit: 5 decimal digits / 4 hex digits max
+    uint8_t n = 0;
+    do {
+        uint8_t d = (uint8_t)(val % base);
+        buf[n++]  = (char)(d < 10 ? '0' + d : (upper ? 'A' : 'a') + d - 10);
+        val /= base;
+    } while (val);
+    for (uint8_t w = n; w < width; w++) {
+        console_putc((unsigned char)pad);
+    }
+    while (n) {
+        console_putc((unsigned char)buf[--n]);
+    }
+}
+
+void console_printf(const __code char *fmt, ...) __reentrant
+{
+    va_list ap;
+    va_start(ap, fmt);
+
+    for (char c = *fmt; c; c = *++fmt) {
+        if (c != '%') {
+            console_putc((unsigned char)c);
+            continue;
+        }
+
+        c             = *++fmt;
+        char    pad   = ' ';
+        uint8_t width = 0;
+        if (c == '0') {
+            pad = '0';
+            c   = *++fmt;
+        }
+        if (c >= '1' && c <= '9') {
+            width = (uint8_t)(c - '0');
+            c     = *++fmt;
+        }
+
+        switch (c) {
+            case 'c':
+                console_putc((unsigned char)va_arg(ap, int));
+                break;
+            case 's': {
+                const char *s = va_arg(ap, const char *);
+                while (*s)
+                    console_putc((unsigned char)*s++);
+                break;
+            }
+            case 'd': {
+                int v = va_arg(ap, int);
+                if (v < 0) {
+                    console_putc('-');
+                    v = -v;
+                }
+                console_emit_num((uint16_t)v, 10, width, pad, 0);
+                break;
+            }
+            case 'u':
+                console_emit_num((uint16_t)va_arg(ap, unsigned int), 10, width, pad, 0);
+                break;
+            case 'x':
+                console_emit_num((uint16_t)va_arg(ap, unsigned int), 16, width, pad, 0);
+                break;
+            case 'X':
+                console_emit_num((uint16_t)va_arg(ap, unsigned int), 16, width, pad, 1);
+                break;
+            case '%':
+                console_putc('%');
+                break;
+            case 0:
+                va_end(ap);
+                return;
+            default:
+                console_putc('%');
+                console_putc((unsigned char)c);
+                break;
+        }
+    }
+
+    va_end(ap);
+}
 
 #    define CONSOLE_BUF_SIZE 128 // must stay a power of two
 #    define CONSOLE_BUF_MASK (CONSOLE_BUF_SIZE - 1)
@@ -13,6 +98,13 @@
 static __xdata unsigned char    console_buf[CONSOLE_BUF_SIZE];
 static volatile __xdata uint8_t console_head; // producer (console_putc)
 static volatile __xdata uint8_t console_tail; // consumer (console_task)
+
+static __xdata uint8_t console_attached;
+
+void console_notify_attached(void)
+{
+    console_attached = 1;
+}
 
 void console_putc(unsigned char c)
 {
@@ -29,16 +121,16 @@ void console_putc(unsigned char c)
     }
 }
 
-// Drains buffered bytes into the EP2 IN buffer as a REPORT_ID_CONSOLE HID report.
-// Writes the hardware endpoint buffer directly (rather than via a helper taking
-// a pointer/length) to avoid spending the SH68F90A's last bytes of internal RAM
-// on parameter passing.
 void console_task(void)
 {
     uint8_t len;
 
     if (!usb_is_configured()) {
-        return; // not enumerated over USB (e.g. wireless mode / unplugged)
+        console_attached = 0; // require a fresh handshake after re-enumeration
+        return;               // not enumerated over USB (e.g. wireless / unplugged)
+    }
+    if (!console_attached) {
+        return; // host tool hasn't announced itself yet; keep buffering
     }
     if (console_head == console_tail) {
         return; // nothing buffered

--- a/src/smk/console.h
+++ b/src/smk/console.h
@@ -1,9 +1,10 @@
 #pragma once
 
-// Debug console over USB HID. Bytes written with console_putc() are queued in a
-// ring buffer and drained to the host as REPORT_ID_CONSOLE HID input reports by
-// console_task(), which must be called periodically from the main loop. Only
-// active in DEBUG builds; see putchar() in uart.c for the stdio hookup.
+#include <stdint.h>
 
 void console_putc(unsigned char c);
 void console_task(void);
+
+void console_notify_attached(void);
+
+void console_printf(const __code char *fmt, ...) __reentrant;

--- a/src/smk/debug.h
+++ b/src/smk/debug.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <stdio.h>
+#include "console.h"
 
-#define dprintf(...)                    \
-    do {                                \
-        if (DEBUG) printf(__VA_ARGS__); \
+#define dprintf(...)                            \
+    do {                                        \
+        if (DEBUG) console_printf(__VA_ARGS__); \
     } while (0)

--- a/tools/smk-console.c
+++ b/tools/smk-console.c
@@ -2,8 +2,14 @@
 //
 // SMK (DEBUG builds) ships debug text as HID input reports with report id
 // REPORT_ID_CONSOLE (7) on its "extra" interface. This tool opens every
-// /dev/hidraw* node matching the given VID:PID, and prints the payload of any
-// report 7 it sees. Reading hidraw nodes usually requires root.
+// /dev/hidraw* node matching the given VID:PID and prints the payload of any
+// report 7 it sees, picking up and dropping matching devices as they appear or
+// disappear. Reading hidraw nodes usually requires root.
+//
+// On connect it sends a SET_REPORT(Feature, 7) handshake: the firmware holds
+// its console output buffered until a tool announces itself this way, then
+// flushes everything queued so far (including the boot banner), defeating the
+// attach race where the kernel would drain a one-shot report first.
 //
 //   cc -O2 -o smk-console tools/smk-console.c
 //   sudo ./smk-console            # defaults to 05ac:024f (nuphy-air60)
@@ -22,6 +28,59 @@
 
 #define REPORT_ID_CONSOLE 7
 #define MAX_DEVS          32
+#define RESCAN_MS         500
+
+static struct pollfd fds[MAX_DEVS];
+static char          paths[MAX_DEVS][300];
+static int           nfds;
+
+static int already_open(const char *path)
+{
+    for (int i = 0; i < nfds; i++) {
+        if (strcmp(paths[i], path) == 0) return 1;
+    }
+    return 0;
+}
+
+static void scan(unsigned vid, unsigned pid)
+{
+    DIR *d = opendir("/dev");
+    if (!d) return;
+    struct dirent *e;
+    while ((e = readdir(d)) && nfds < MAX_DEVS) {
+        if (strncmp(e->d_name, "hidraw", 6) != 0) continue;
+        char path[300];
+        snprintf(path, sizeof(path), "/dev/%s", e->d_name);
+        if (already_open(path)) continue;
+        int fd = open(path, O_RDWR);
+        if (fd < 0) fd = open(path, O_RDONLY);
+        if (fd < 0) continue;
+        struct hidraw_devinfo info;
+        if (ioctl(fd, HIDIOCGRAWINFO, &info) == 0 && (uint16_t)info.vendor == vid && (uint16_t)info.product == pid) {
+            fprintf(stderr, "[smk-console] connected %s\n", path);
+            unsigned char hello[5] = {REPORT_ID_CONSOLE, 'S', 'M', 'K', 0};
+            ioctl(fd, HIDIOCSFEATURE(sizeof(hello)), hello);
+            fds[nfds].fd      = fd;
+            fds[nfds].events  = POLLIN;
+            fds[nfds].revents = 0;
+            snprintf(paths[nfds], sizeof(paths[nfds]), "%s", path);
+            nfds++;
+        } else {
+            close(fd);
+        }
+    }
+    closedir(d);
+}
+
+static void drop(int i)
+{
+    fprintf(stderr, "[smk-console] disconnected %s\n", paths[i]);
+    close(fds[i].fd);
+    int last = nfds - 1;
+    fds[i]   = fds[last];
+    memcpy(paths[i], paths[last], sizeof(paths[i]));
+    nfds--;
+}
 
 int main(int argc, char **argv)
 {
@@ -31,55 +90,31 @@ int main(int argc, char **argv)
         return 2;
     }
 
-    struct pollfd fds[MAX_DEVS];
-    int           nfds = 0;
-
-    // Wait up to ~15s for matching hidraw nodes so we survive a reboot/re-enum.
-    for (int tries = 0; tries < 75 && nfds == 0; tries++) {
-        DIR *d = opendir("/dev");
-        if (!d) {
-            perror("opendir /dev");
-            return 1;
-        }
-        struct dirent *e;
-        while ((e = readdir(d)) && nfds < MAX_DEVS) {
-            if (strncmp(e->d_name, "hidraw", 6) != 0) continue;
-            char path[300];
-            snprintf(path, sizeof(path), "/dev/%s", e->d_name);
-            int fd = open(path, O_RDONLY);
-            if (fd < 0) continue;
-            struct hidraw_devinfo info;
-            if (ioctl(fd, HIDIOCGRAWINFO, &info) == 0 && (uint16_t)info.vendor == vid && (uint16_t)info.product == pid) {
-                fprintf(stderr, "[smk-console] listening on %s\n", path);
-                fds[nfds].fd     = fd;
-                fds[nfds].events = POLLIN;
-                nfds++;
-            } else {
-                close(fd);
-            }
-        }
-        closedir(d);
-        if (nfds == 0) usleep(200000);
-    }
-
-    if (nfds == 0) {
-        fprintf(stderr,
-                "[smk-console] no hidraw node for %04x:%04x "
-                "(device present? permission? DEBUG build flashed?)\n",
-                vid, pid);
-        return 1;
-    }
+    fprintf(stderr, "[smk-console] watching for %04x:%04x (Ctrl-C to quit)\n", vid, pid);
 
     uint8_t buf[64];
     for (;;) {
-        if (poll(fds, nfds, -1) < 0) {
+        scan(vid, pid);
+
+        int r = poll(fds, nfds, RESCAN_MS);
+        if (r < 0) {
             perror("poll");
             return 1;
         }
-        for (int i = 0; i < nfds; i++) {
-            if (!(fds[i].revents & POLLIN)) continue;
+        if (r == 0) continue;
+
+        for (int i = nfds - 1; i >= 0; i--) {
+            short re = fds[i].revents;
+            if (re & (POLLHUP | POLLERR | POLLNVAL)) {
+                drop(i);
+                continue;
+            }
+            if (!(re & POLLIN)) continue;
             int n = read(fds[i].fd, buf, sizeof(buf));
-            if (n <= 0) continue;
+            if (n <= 0) {
+                drop(i);
+                continue;
+            }
             if (buf[0] != REPORT_ID_CONSOLE) continue;
             for (int j = 1; j < n && buf[j] != 0; j++) {
                 putchar(buf[j]);


### PR DESCRIPTION
Routes dprintf into a ring buffer drained to the host as report id 7, held until the host handshakes so buffered output is not lost, with smk-console to read it.