### PR TITLE
Fix the release build and cover it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         nkro: [enabled, disabled]
+        buildtype: [debug, release]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -24,13 +25,13 @@ jobs:
         name: smk
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
     - name: Setup
-      run: nix develop --command meson setup build -Dnkro=${{ matrix.nkro }}
+      run: nix develop --command meson setup build -Dnkro=${{ matrix.nkro }} -Dbuildtype=${{ matrix.buildtype }}
     - name: Build
       run: nix develop --command meson compile -C build
     - name: Archive code coverage results
       uses: actions/upload-artifact@v7
       with:
-        name: smk-${{ matrix.nkro == 'enabled' && 'nkro' || '6kro' }}
+        name: smk-${{ matrix.buildtype }}-${{ matrix.nkro == 'enabled' && 'nkro' || '6kro' }}
         path: build/*.hex
 
   sim-tests:

--- a/meson.build
+++ b/meson.build
@@ -167,11 +167,6 @@ sdar = find_program('sdar', required : true)
 packihx = find_program('packihx', required : true)
 sinowisp = find_program('sinowisp', required : true)
 
-# experiment: --stack-auto needs libsdcc (_bp/_bpx frame pointers). This SDCC's
-# reported libpath is empty (nix quirk), so the linker can't find the model libs;
-# point it at the model-variant lib dir explicitly.
-sdcc_libdir = fs.parent(fs.parent(cc.full_path())) / 'share/sdcc/lib/large-stack-auto'
-
 # SDCC can't emit header dependencies as a compile side-effect (its -M family is
 # deps-only), so we drive it through a small wrapper that also writes a depfile —
 # this is what makes ninja rebuild a .rel when one of its headers changes.
@@ -243,8 +238,6 @@ foreach part : parts
             '-DWATCHDOG_ENABLE=@0@'.format(options['watchdog_enable']),
             '-DUSB_VID=@0@'.format(options['vendor_id']),
             '-DUSB_PID=@0@'.format(options['product_id']),
-            # build-time identity, as ready-to-use string literals (names have
-            # hyphens, so quote rather than rely on token stringizing)
             '-DKEYBOARD_NAME="@0@"'.format(keyboard),
             '-DLAYOUT_NAME="@0@"'.format(layout),
         ]
@@ -325,7 +318,7 @@ foreach part : parts
             input : rel_main,
             output : ihx_smk_target_name,
             depends: [lib_user],
-            command : [cc, cc_args, '--lib-path', sdcc_libdir, '-o', '@OUTPUT@', '@INPUT@', '-l' + lib_user.full_path()],
+            command : [cc, cc_args, '-o', '@OUTPUT@', '@INPUT@', '-l' + lib_user.full_path()],
         )
 
         # Overlay/interrupt-safety gate: reads the just-linked .map + per-module .asm

--- a/src/keyboards/nuphy-air60/user_init.c
+++ b/src/keyboards/nuphy-air60/user_init.c
@@ -51,8 +51,9 @@ void user_gpio_init()
     P5PCR = (uint8_t)(KB_R3_P5_3 | KB_R4_P5_4 | CONN_MODE_SWITCH_P5_5 | OS_MODE_SWITCH_P5_6);
     P7PCR = (uint8_t)(KB_R0_P7_1 | KB_R1_P7_2 | KB_R2_P7_3);
 
-    if (DEBUG) {
-    }
+    // FIXME: UART TXD shares its pin with CONN_MODE_SWITCH, so a
+    // DEBUG_SINK_UART build and the connection slider can't both work. Nothing
+    // here reconciles them yet.
 
     // BB SPI pins for RF. Pins idle as INPUT with pull-up enabled (idle HIGH).
     // During each SPI bit the bit-bang functions briefly switch the pin to OUTPUT

--- a/src/platform/bk3632/rf_controller.c
+++ b/src/platform/bk3632/rf_controller.c
@@ -189,11 +189,9 @@ bool rf_update_keyboard_state(keyboard_state_t *keyboard)
     keyboard->paired    = (status_bytes[1] >> 4) & 1;
     keyboard->low_power = (status_bytes[1] >> 7) & 1;
 
-    uint8_t old_rf_link = keyboard->rf_link;
-    keyboard->rf_link   = ((status_bytes[1] & ((1 << 5) | (1 << 6))) >> 5);
-    if (old_rf_link != keyboard->rf_link) {
-        dprintf("rf link changed %02x\r\n", keyboard->rf_link);
-    }
+    const uint8_t old_rf_link = keyboard->rf_link;
+    keyboard->rf_link         = ((status_bytes[1] & ((1 << 5) | (1 << 6))) >> 5);
+    dprintf_if(old_rf_link != keyboard->rf_link, "rf link changed %02x\r\n", keyboard->rf_link);
 
     return true;
 }

--- a/src/smk/debug.h
+++ b/src/smk/debug.h
@@ -2,7 +2,17 @@
 
 #include "console.h"
 
-#define dprintf(...)                            \
-    do {                                        \
-        if (DEBUG) console_printf(__VA_ARGS__); \
-    } while (0)
+#if DEBUG == 1
+#    define dprintf(...) console_printf(__VA_ARGS__)
+#else
+#    define dprintf(...) ((void)0)
+#endif
+
+#if DEBUG == 1
+#    define dprintf_if(cond, ...)           \
+        do {                                \
+            if (cond) dprintf(__VA_ARGS__); \
+        } while (0)
+#else
+#    define dprintf_if(cond, ...) ((void)(cond))
+#endif


### PR DESCRIPTION
Gates dprintf at the preprocessor so release builds stop failing on an undefined DEBUG, adds buildtype to the CI matrix, and drops a --lib-path override that no longer has any effect.