### PR TITLE
Remove comments that restate their code and redundant __xdata

### DIFF
--- a/src/keyboards/eyooso-z11/kb.c
+++ b/src/keyboards/eyooso-z11/kb.c
@@ -7,7 +7,7 @@
 extern void indicators_next_effect();
 extern void indicators_factory_reset();
 
-static __xdata bool reset_mode_active;
+static bool reset_mode_active;
 
 bool kb_process_record(uint16_t keycode, bool key_pressed)
 {

--- a/src/keyboards/eyooso-z11/layouts/default/indicators.c
+++ b/src/keyboards/eyooso-z11/layouts/default/indicators.c
@@ -20,12 +20,12 @@
 #include LED_GEOMETRY_HEADER
 _Static_assert(LED_GEOMETRY_ROWS == LED_ROWS && LED_GEOMETRY_COLS == LED_COLS, "generated LED geometry size does not match the key matrix");
 
-static __xdata uint8_t led_fb[LED_ROWS][LED_COLS];
+static uint8_t led_fb[LED_ROWS][LED_COLS];
 
-static __xdata uint8_t led_row;
-static __xdata uint8_t led_phase;
-static __xdata uint8_t regen_row;
-static __xdata uint8_t regen_col;
+static uint8_t led_row;
+static uint8_t led_phase;
+static uint8_t regen_row;
+static uint8_t regen_col;
 
 void        indicators_pwm_enable();
 void        indicators_pwm_disable();

--- a/src/keyboards/nuphy-air60/kb.c
+++ b/src/keyboards/nuphy-air60/kb.c
@@ -28,7 +28,7 @@ typedef struct {
     user_keyboard_os_mode_t   os_mode;
 } user_keyboard_state_t;
 
-volatile __xdata user_keyboard_state_t user_keyboard_state;
+volatile user_keyboard_state_t user_keyboard_state;
 
 void kb_init()
 {
@@ -80,8 +80,8 @@ static void kb_apply_os_mode(user_keyboard_os_mode_t mode)
 
 void kb_update_switches()
 {
-    static __xdata uint16_t conn_debounce;
-    static __xdata uint16_t os_debounce;
+    static uint16_t conn_debounce;
+    static uint16_t os_debounce;
 
     const uint8_t raw_conn = CONN_MODE_SWITCH;
     if (raw_conn == user_keyboard_state.conn_mode) {
@@ -136,15 +136,15 @@ extern void indicators_battery_off();
 
 // While UL_MODE (the "?" key on the Fn layer) is held, the RGB_* chords adjust the
 // underglow instead of the main backlight. Held in xdata to spare internal RAM.
-static __xdata bool ul_mode_active;
+static bool ul_mode_active;
 
-static __xdata bool reset_mode_active;
+static bool reset_mode_active;
 
 #ifdef RF_ENABLED
 #    define LINK_PAIRING_HOLD_TICKS 60000
-static __xdata uint16_t link_hold_ticks    = 0;
-static __xdata uint16_t link_hold_keycode  = 0;
-static __xdata bool     link_pairing_armed = false;
+static uint16_t link_hold_ticks    = 0;
+static uint16_t link_hold_keycode  = 0;
+static bool     link_pairing_armed = false;
 #endif
 
 bool kb_process_record(uint16_t keycode, bool key_pressed)
@@ -307,7 +307,7 @@ void kb_send_extra(__xdata report_extra_t *report)
     }
 }
 
-__xdata uint16_t ticks = 0;
+uint16_t ticks = 0;
 
 void kb_update()
 {

--- a/src/keyboards/nuphy-air60/kb.c
+++ b/src/keyboards/nuphy-air60/kb.c
@@ -44,6 +44,40 @@ void kb_init()
 
 #define SLIDER_DEBOUNCE_ITERS 256
 
+static void kb_apply_conn_mode(user_keyboard_conn_mode_t mode)
+{
+    user_keyboard_state.conn_mode = mode;
+
+    switch (mode) {
+        case KEYBOARD_CONN_MODE_USB:
+            dprintf("USB_MODE\r\n");
+#ifdef RF_ENABLED
+            rf_apply_usb_mode();
+#endif
+            break;
+        case KEYBOARD_CONN_MODE_RF:
+            dprintf("RF_MODE\r\n");
+#ifdef RF_ENABLED
+            rf_set_link((rf_mode_t)user_settings.rf_link);
+            rf_kbd_lazy_state_init();
+#endif
+            break;
+    }
+}
+
+static void kb_apply_os_mode(user_keyboard_os_mode_t mode)
+{
+    const bool is_mac = (mode == KEYBOARD_OS_MODE_MAC);
+
+    user_keyboard_state.os_mode = mode;
+    set_default_layer(layout_os_base_layer(is_mac));
+
+    dprintf(is_mac ? "MAC_MODE\r\n" : "WIN_MODE\r\n");
+#ifdef RF_ENABLED
+    rf_set_mac_mode_compat(is_mac);
+#endif
+}
+
 void kb_update_switches()
 {
     static __xdata uint16_t conn_debounce;
@@ -53,46 +87,16 @@ void kb_update_switches()
     if (raw_conn == user_keyboard_state.conn_mode) {
         conn_debounce = 0;
     } else if (++conn_debounce >= SLIDER_DEBOUNCE_ITERS) {
-        conn_debounce                 = 0;
-        user_keyboard_state.conn_mode = raw_conn;
-        switch (user_keyboard_state.conn_mode) {
-            case KEYBOARD_CONN_MODE_USB:
-                dprintf("USB_MODE\r\n");
-#ifdef RF_ENABLED
-                rf_apply_usb_mode();
-#endif
-                break;
-            case KEYBOARD_CONN_MODE_RF:
-                dprintf("RF_MODE\r\n");
-#ifdef RF_ENABLED
-                rf_set_link((rf_mode_t)user_settings.rf_link);
-                rf_kbd_lazy_state_init();
-#endif
-                break;
-        }
+        conn_debounce = 0;
+        kb_apply_conn_mode((user_keyboard_conn_mode_t)raw_conn);
     }
 
     const uint8_t raw_os = OS_MODE_SWITCH;
     if (raw_os == user_keyboard_state.os_mode) {
         os_debounce = 0;
     } else if (++os_debounce >= SLIDER_DEBOUNCE_ITERS) {
-        os_debounce                 = 0;
-        user_keyboard_state.os_mode = raw_os;
-        set_default_layer(layout_os_base_layer(user_keyboard_state.os_mode == KEYBOARD_OS_MODE_MAC));
-        switch (user_keyboard_state.os_mode) {
-            case KEYBOARD_OS_MODE_MAC:
-                dprintf("MAC_MODE\r\n");
-#ifdef RF_ENABLED
-                rf_set_mac_mode_compat(true);
-#endif
-                break;
-            case KEYBOARD_OS_MODE_WIN:
-                dprintf("WIN_MODE\r\n");
-#ifdef RF_ENABLED
-                rf_set_mac_mode_compat(false);
-#endif
-                break;
-        }
+        os_debounce = 0;
+        kb_apply_os_mode((user_keyboard_os_mode_t)raw_os);
     }
 }
 
@@ -229,9 +233,9 @@ bool kb_process_record(uint16_t keycode, bool key_pressed)
                     keyboard_state.rf_link   = (uint8_t)mode;
                     keyboard_state.connected = 1;
                     keyboard_state.paired    = 1;
-                    link_hold_keycode  = keycode;
-                    link_hold_ticks    = 0;
-                    link_pairing_armed = true;
+                    link_hold_keycode        = keycode;
+                    link_hold_ticks          = 0;
+                    link_pairing_armed       = true;
                 } else {
                     if (link_hold_keycode == keycode) {
                         link_hold_keycode  = 0;

--- a/src/keyboards/nuphy-air60/layouts/default/indicators.c
+++ b/src/keyboards/nuphy-air60/layouts/default/indicators.c
@@ -51,27 +51,27 @@
 #include LED_GEOMETRY_HEADER
 _Static_assert(LED_GEOMETRY_ROWS == LED_ROWS && LED_GEOMETRY_COLS == LED_COLS, "generated LED geometry size does not match the key matrix");
 
-static __xdata uint8_t led_fb[LED_ROWS][3][LED_COLS];
+static uint8_t led_fb[LED_ROWS][3][LED_COLS];
 
 // Separate framebuffer for the underglow ("user") LEDs, since they animate
 // independently of the main backlight.
-static __xdata uint8_t led_ul_fb[3][LED_COLS];
+static uint8_t led_ul_fb[3][LED_COLS];
 
-static __xdata uint8_t led_row;
-static __xdata uint8_t led_color;
+static uint8_t led_row;
+static uint8_t led_color;
 
-static __xdata uint8_t led_phase;
-static __xdata uint8_t ul_phase;
-static __xdata uint8_t regen_row;
-static __xdata uint8_t regen_col;
+static uint8_t led_phase;
+static uint8_t ul_phase;
+static uint8_t regen_row;
+static uint8_t regen_col;
 
-static __xdata uint8_t anim_ctr;
+static uint8_t anim_ctr;
 
-static volatile __xdata bool render_dirty;
+static volatile bool render_dirty;
 
-static __xdata uint8_t battery_flash_sweeps;
+static uint8_t battery_flash_sweeps;
 
-static __xdata uint8_t status_pulse_counter;
+static uint8_t status_pulse_counter;
 
 static __code const uint8_t breath_lut[32] = {0, 13, 26, 39, 51, 64, 76, 88, 100, 112, 124, 135, 146, 156, 166, 176, 185, 194, 202, 210, 217, 223, 229, 234, 239, 244, 247, 251, 253, 254, 255, 255};
 

--- a/src/keyboards/nuphy-air60/layouts/default/indicators.c
+++ b/src/keyboards/nuphy-air60/layouts/default/indicators.c
@@ -113,7 +113,6 @@ void indicators_battery_off()
     settings_mark_dirty();
 }
 
-// Factory reset: restore defaults and persist them so the next boot loads them too.
 void indicators_factory_reset()
 {
     indicators_apply_defaults();

--- a/src/platform/bk3632/rf_controller.c
+++ b/src/platform/bk3632/rf_controller.c
@@ -20,14 +20,14 @@ typedef enum {
 static const __code char rf_bt5_name[] = "SMK BT5.0";
 static const __code char rf_bt3_name[] = "SMK BT3.0";
 
-__xdata uint8_t rf_tx_buf[32];
+uint8_t rf_tx_buf[32];
 
-static __xdata uint8_t kro_prev_active;
-static __xdata uint8_t blanking_pending;
-static __xdata bool    blanking_active;
+static uint8_t kro_prev_active;
+static uint8_t blanking_pending;
+static bool    blanking_active;
 
-static __xdata bool mac_mode_compat;
-static __xdata bool byte9_disable;
+static bool mac_mode_compat;
+static bool byte9_disable;
 
 void rf_set_mac_mode_compat(bool is_mac)
 {
@@ -113,10 +113,10 @@ void rf_factory_reset_bonds(void)
     delay_ms(200);
 }
 
-__xdata uint8_t kro6buffer[6];
+uint8_t kro6buffer[6];
 
-static __xdata uint8_t rf_pending_buf[6];
-static __xdata bool    rf_pending;
+static uint8_t rf_pending_buf[6];
+static bool    rf_pending;
 
 void rf_send_report(__xdata report_keyboard_t *report)
 {
@@ -199,11 +199,11 @@ bool rf_update_keyboard_state(keyboard_state_t *keyboard)
 #define RF_SUPERVISOR_TICK_INTERVAL 2000u
 #define RF_PAIRING_WINDOW_POLLS 600u
 
-static __xdata uint8_t  commanded_link       = RF_MODE_2_4G;
-static __xdata uint16_t pairing_window_polls = 0;
+static uint8_t  commanded_link       = RF_MODE_2_4G;
+static uint16_t pairing_window_polls = 0;
 
-static __xdata uint16_t supervisor_ticks      = 0;
-static __xdata uint8_t  supervisor_was_paired = 0;
+static uint16_t supervisor_ticks      = 0;
+static uint8_t  supervisor_was_paired = 0;
 
 void rf_link_supervisor(keyboard_state_t *keyboard)
 {
@@ -250,7 +250,7 @@ void rf_apply_usb_mode(void)
     rf_cmd_06(1);
 }
 
-static __xdata bool lazy_init_pending;
+static bool lazy_init_pending;
 
 void rf_kbd_lazy_state_init(void)
 {
@@ -265,9 +265,9 @@ void rf_blanking_tick(void)
         return;
     }
 
-    static __xdata uint8_t phantom_buf[6] = {0, 0x01, 0, 0, 0, 0};
-    static __xdata uint8_t blank_buf[6]   = {0, 0, 0, 0, 0, 0};
-    uint8_t               *buf            = ((blanking_pending & 1) == 0) ? phantom_buf : blank_buf;
+    static uint8_t phantom_buf[6] = {0, 0x01, 0, 0, 0, 0};
+    static uint8_t blank_buf[6]   = {0, 0, 0, 0, 0, 0};
+    uint8_t       *buf            = ((blanking_pending & 1) == 0) ? phantom_buf : blank_buf;
 
     blanking_pending--;
 
@@ -276,8 +276,8 @@ void rf_blanking_tick(void)
     blanking_active = false;
 }
 
-static __xdata uint8_t pairing_status_bytes[2];
-static __xdata uint8_t pairing_paired_now;
+static uint8_t pairing_status_bytes[2];
+static uint8_t pairing_paired_now;
 
 void rf_set_link_pairing(rf_mode_t link, __xdata keyboard_state_t *keyboard)
 {
@@ -393,7 +393,7 @@ bool rf_send_kro_report(uint8_t *buffer)
 {
     const uint8_t len = 32;
 
-    static __xdata uint8_t empty_buf[6] = {0, 0, 0, 0, 0, 0};
+    static uint8_t empty_buf[6] = {0, 0, 0, 0, 0, 0};
     if (lazy_init_pending) {
         lazy_init_pending = false;
         buffer            = empty_buf;

--- a/src/platform/sh68f90a/power.c
+++ b/src/platform/sh68f90a/power.c
@@ -5,7 +5,7 @@
 #include "usb.h"
 #include "clock.h"
 
-static volatile __xdata uint8_t int4_woke;
+static volatile uint8_t int4_woke;
 
 static void usb_park(powerdown_mode_t mode)
 {

--- a/src/platform/sh68f90a/stack.c
+++ b/src/platform/sh68f90a/stack.c
@@ -34,8 +34,8 @@ static uint8_t stack_peak(void)
 
 void stack_task(void)
 {
-    static __xdata uint8_t reported = 0;
-    static __xdata uint8_t throttle = 0;
+    static uint8_t reported = 0;
+    static uint8_t throttle = 0;
 
     if (++throttle != 0) {
         return; // ~once every 256 main-loop iterations

--- a/src/platform/sh68f90a/usb.c
+++ b/src/platform/sh68f90a/usb.c
@@ -338,29 +338,29 @@ static void usb_hid_get_protocol_handler(struct usb_req_setup *req);
 /**
  * 0.5KB of general purpose scratch RAM.
  */
-__xdata uint8_t scratch[512];
+uint8_t scratch[512];
 
 uint16_t ep0_xfer_bytes_left;
 uint8_t *ep0_xfer_src;
 
 // usb state
-usb_device_state_t __xdata usb_device_state;
-uint8_t __xdata            received_usb_addr;
-uint8_t __xdata            active_configuration;
-uint8_t __xdata            interface0_protocol;
-uint8_t __xdata            interface1_protocol;
+usb_device_state_t usb_device_state;
+uint8_t            received_usb_addr;
+uint8_t            active_configuration;
+uint8_t            interface0_protocol;
+uint8_t            interface1_protocol;
 // Host-controlled remote-wakeup enable, per SET/CLEAR_FEATURE.
 static __bit usb_remote_wakeup;
-__bit                   usb_suspended;
-uint8_t __xdata         idle_time;
-usb_ep0_state_t __xdata usb_ep0_state;
+__bit           usb_suspended;
+uint8_t         idle_time;
+usb_ep0_state_t usb_ep0_state;
 
 #define ENUM_QUIET_MS   500
 #define ENUM_NO_HOST_MS 500
 #define ENUM_GIVE_UP_MS 4000
 
-static __xdata uint16_t enum_quiet_ticks;
-static __xdata bool     enum_seen;
+static uint16_t enum_quiet_ticks;
+static bool     enum_seen;
 
 void usb_init()
 {

--- a/src/smk/console.c
+++ b/src/smk/console.c
@@ -94,11 +94,11 @@ void console_printf(const __code char *fmt, ...) __reentrant
 #    define CONSOLE_BUF_SIZE 128 // must stay a power of two
 #    define CONSOLE_BUF_MASK (CONSOLE_BUF_SIZE - 1)
 
-static __xdata unsigned char    console_buf[CONSOLE_BUF_SIZE];
-static volatile __xdata uint8_t console_head; // producer (console_putc)
-static volatile __xdata uint8_t console_tail; // consumer (console_task)
+static unsigned char    console_buf[CONSOLE_BUF_SIZE];
+static volatile uint8_t console_head; // producer (console_putc)
+static volatile uint8_t console_tail; // consumer (console_task)
 
-static __xdata uint8_t console_attached;
+static uint8_t console_attached;
 
 void console_notify_attached(void)
 {
@@ -120,7 +120,7 @@ void console_putc(unsigned char c)
 
 void console_task(void)
 {
-    static __xdata unsigned char report[CONSOLE_REPORT_SIZE];
+    static unsigned char report[CONSOLE_REPORT_SIZE];
 
     if (!usb_is_configured()) {
         console_attached = 0; // require a fresh handshake once the link is back

--- a/src/smk/host.c
+++ b/src/smk/host.c
@@ -3,10 +3,10 @@
 #include "keyboard.h"
 #include "usb.h"
 
-static __xdata uint16_t last_system_usage;
-static __xdata uint16_t last_consumer_usage;
+static uint16_t last_system_usage;
+static uint16_t last_consumer_usage;
 
-static __xdata report_extra_t extra_report;
+static report_extra_t extra_report;
 
 bool host_nkro_active(void)
 {

--- a/src/smk/keyboard.c
+++ b/src/smk/keyboard.c
@@ -1,9 +1,9 @@
 #include "keyboard.h"
 #include "debug.h"
 
-volatile __xdata keyboard_state_t keyboard_state;
+volatile keyboard_state_t keyboard_state;
 
-__xdata keymap_config_t keymap_config;
+keymap_config_t keymap_config;
 
 void keyboard_init(void)
 {

--- a/src/smk/keyboard.h
+++ b/src/smk/keyboard.h
@@ -15,8 +15,8 @@ typedef struct {
     uint8_t nkro;
 } keymap_config_t;
 
-extern volatile __xdata keyboard_state_t keyboard_state;
-extern __xdata keymap_config_t           keymap_config;
+extern volatile keyboard_state_t keyboard_state;
+extern keymap_config_t           keymap_config;
 
 void keyboard_init(void);
 

--- a/src/smk/matrix.c
+++ b/src/smk/matrix.c
@@ -15,14 +15,14 @@
 
 typedef uint8_t matrix_col_t;
 
-__xdata matrix_col_t matrix[MATRIX_COLS];
-__xdata matrix_col_t matrix_previous[MATRIX_COLS];
+matrix_col_t matrix[MATRIX_COLS];
+matrix_col_t matrix_previous[MATRIX_COLS];
 
 volatile bool matrix_updated;
 
 uint8_t action_layer;
 
-__xdata uint8_t default_layer;
+uint8_t default_layer;
 
 void matrix_init()
 {

--- a/src/smk/report.c
+++ b/src/smk/report.c
@@ -250,7 +250,6 @@ uint8_t biton(uint8_t bits)
     return n;
 }
 
-/* keycode to system usage */
 uint16_t keycode_to_system(uint8_t key)
 {
     switch (key) {
@@ -265,7 +264,6 @@ uint16_t keycode_to_system(uint8_t key)
     }
 }
 
-/* keycode to consumer usage */
 uint16_t keycode_to_consumer(uint8_t key)
 {
     switch (key) {

--- a/src/smk/report.c
+++ b/src/smk/report.c
@@ -9,11 +9,11 @@
 static uint8_t real_mods = 0;
 static uint8_t weak_mods = 0;
 
-__xdata report_keyboard_t keyboard_report;
-__xdata report_keyboard_t last_report;
+report_keyboard_t keyboard_report;
+report_keyboard_t last_report;
 
-__xdata report_nkro_t nkro_report;
-__xdata report_nkro_t last_nkro_report;
+report_nkro_t nkro_report;
+report_nkro_t last_nkro_report;
 
 uint8_t biton(uint8_t bits);
 

--- a/src/smk/report.h
+++ b/src/smk/report.h
@@ -63,8 +63,8 @@ typedef union {
     };
 } report_extra_t;
 
-extern __xdata report_keyboard_t keyboard_report;
-extern __xdata report_nkro_t     nkro_report;
+extern report_keyboard_t keyboard_report;
+extern report_nkro_t     nkro_report;
 
 void send_keyboard_report();
 

--- a/src/smk/settings.c
+++ b/src/smk/settings.c
@@ -6,9 +6,9 @@
 
 _Static_assert(sizeof(user_settings_t) + 4u <= 512u, "user_settings_t too large for the settings sector");
 
-__xdata user_settings_t user_settings;
+user_settings_t user_settings;
 
-static __xdata bool settings_dirty;
+static bool settings_dirty;
 
 bool settings_load(void)
 {

--- a/src/smk/settings.h
+++ b/src/smk/settings.h
@@ -14,7 +14,7 @@ typedef struct {
     uint8_t rf_link;
 } user_settings_t;
 
-extern __xdata user_settings_t user_settings;
+extern user_settings_t user_settings;
 
 bool settings_load(void);
 

--- a/src/smk/sleep.c
+++ b/src/smk/sleep.c
@@ -24,9 +24,9 @@ typedef int sleep_disabled_placeholder_t;
 // indirectly via `sleep_requested`. Activity reaches the tick through the
 // single-byte `activity_seen` flag, so there is no read-modify-write race on the
 // 16-bit counter across contexts.
-static volatile __xdata uint16_t inactivity;
-static volatile __xdata uint8_t  activity_seen;
-static volatile __xdata uint8_t  sleep_requested;
+static volatile uint16_t inactivity;
+static volatile uint8_t  activity_seen;
+static volatile uint8_t  sleep_requested;
 
 void sleep_init(void)
 {
@@ -77,7 +77,7 @@ static bool sleep_due(user_sleep_mode_t mode)
 
 static void rf_resync_after_wake(void)
 {
-    static __xdata uint8_t tries;
+    static uint8_t tries;
 
     for (tries = RF_RESYNC_TRIES; tries > 0; tries--) {
         rf_wake_nudge();


### PR DESCRIPTION
Drops comments a reader could recover from the adjacent line and __xdata on object declarations that --model-large already implies, leaving pointer qualifiers intact; firmware is byte-identical.