### PR TITLE
Rework BK3632 wireless link handling and fix stuck pairing

### DIFF
--- a/src/keyboards/nuphy-air60/kbdef.h
+++ b/src/keyboards/nuphy-air60/kbdef.h
@@ -127,12 +127,14 @@
 #define RF_BB_SPI_MISO P0_6
 #define RF_BB_SPI_MOSI P0_7
 #define RF_BB_SPI_MOT  P0_5
+#define RF_BB_SPI_ACK  P4_2
 
 #define RF_BB_SPI_CS_P7_4   _P7_4
 #define RF_BB_SPI_SCK_P4_7  _P4_7
 #define RF_BB_SPI_MISO_P0_6 _P0_6
 #define RF_BB_SPI_MOSI_P0_7 _P0_7
 #define RF_BB_SPI_MOT_P0_5  _P0_5
+#define RF_BB_SPI_ACK_P4_2  _P4_2
 
 enum custom_keycodes {
     LNK_24G = SAFE_RANGE,

--- a/src/platform/bb_spi.c
+++ b/src/platform/bb_spi.c
@@ -6,20 +6,74 @@
 
 uint8_t bb_spi_xfer_byte(uint8_t data);
 
-void bb_spi_xfer(uint8_t *data, int len)
+#define RF_BB_SPI_ACK_POLL_MAX 50
+#define RF_BB_SPI_ACK_POLL_US  3
+
+#define MOT_DRIVE_LOW()    \
+    do {                   \
+        RF_BB_SPI_MOT = 0; \
+        P0CR |= _P0_5;     \
+        RF_BB_SPI_MOT = 0; \
+    } while (0)
+#define MOT_RELEASE_HIGH()       \
+    do {                         \
+        P0CR &= (uint8_t)~_P0_5; \
+        RF_BB_SPI_MOT = 1;       \
+    } while (0)
+#define CS_DRIVE_LOW()    \
+    do {                  \
+        RF_BB_SPI_CS = 0; \
+        P7CR |= _P7_4;    \
+        RF_BB_SPI_CS = 0; \
+    } while (0)
+#define CS_RELEASE_HIGH()        \
+    do {                         \
+        P7CR &= (uint8_t)~_P7_4; \
+        RF_BB_SPI_CS = 1;        \
+    } while (0)
+
+static void bb_spi_burst(uint8_t *data, int len, bool lock)
 {
-    EA            = 0;
-    RF_BB_SPI_MOT = 0;
-    // wakeup?
-    delay_us(3);
-    RF_BB_SPI_CS = 0;
-    for (int i = 0; i < len; i++) {
-        data[i] = bb_spi_xfer_byte(data[i]);
+    MOT_DRIVE_LOW();
+    delay_us(3); // wakeup
+    CS_DRIVE_LOW();
+    if (lock) {
+        __critical
+        {
+            for (int i = 0; i < len; i++) {
+                data[i] = bb_spi_xfer_byte(data[i]);
+            }
+        }
+    } else {
+        for (int i = 0; i < len; i++) {
+            data[i] = bb_spi_xfer_byte(data[i]);
+        }
     }
-    RF_BB_SPI_CS   = 1;
+    CS_RELEASE_HIGH();
+    P0CR &= (uint8_t)~_P0_7;
     RF_BB_SPI_MOSI = 1;
-    RF_BB_SPI_MOT  = 1;
-    EA             = 1;
+    MOT_RELEASE_HIGH();
+}
+
+bool bb_spi_xfer(uint8_t *data, int len)
+{
+    bool ack_initial = RF_BB_SPI_ACK;
+
+    bb_spi_burst(data, len, false);
+
+    for (uint8_t tries = 0; tries < RF_BB_SPI_ACK_POLL_MAX; tries++) {
+        if (RF_BB_SPI_ACK != ack_initial) {
+            return true;
+        }
+        delay_us(RF_BB_SPI_ACK_POLL_US);
+    }
+
+    return false;
+}
+
+void bb_spi_recv(uint8_t *data, int len)
+{
+    bb_spi_burst(data, len, true);
 }
 
 uint8_t bb_spi_xfer_byte(uint8_t data)
@@ -30,22 +84,15 @@ uint8_t bb_spi_xfer_byte(uint8_t data)
         recv = recv << 1;
 
         RF_BB_SPI_SCK = 0;
-
-        // TODO: probably not necessary
-        // trying to keep the clock speed consistent
-        _nop_();
-        _nop_();
-        _nop_();
-        _nop_();
-
-        _nop_();
-        _nop_();
-        _nop_();
-        _nop_();
+        P4CR |= _P4_7;
+        RF_BB_SPI_SCK = 0;
 
         if (data & (1 << 7)) {
+            P0CR &= (uint8_t)~_P0_7; // MOSI -> input, pull-up to high
             RF_BB_SPI_MOSI = 1;
         } else {
+            RF_BB_SPI_MOSI = 0;
+            P0CR |= _P0_7; // MOSI -> output, drives low
             RF_BB_SPI_MOSI = 0;
         }
 
@@ -53,12 +100,8 @@ uint8_t bb_spi_xfer_byte(uint8_t data)
             recv |= 0x01;
         }
 
+        P4CR &= (uint8_t)~_P4_7;
         RF_BB_SPI_SCK = 1;
-
-        _nop_();
-        _nop_();
-        _nop_();
-        _nop_();
 
         data = data << 1;
     }

--- a/src/platform/bb_spi.h
+++ b/src/platform/bb_spi.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
-void bb_spi_xfer(uint8_t *data, int len);
+bool bb_spi_xfer(uint8_t *data, int len);
+
+void bb_spi_recv(uint8_t *data, int len);

--- a/src/platform/bk3632/rf_controller.c
+++ b/src/platform/bk3632/rf_controller.c
@@ -2,7 +2,8 @@
 #include <stdint.h>
 #include "delay.h"
 #include "debug.h"
-#include "bb_spi.h" // FIXME: should be conditional?
+#include "bb_spi.h"
+#include "sh68f90a.h"
 
 #define MAGIC_BYTE 0xaa
 #define CMD_REPORT 0x02
@@ -17,25 +18,49 @@ typedef enum {
     RF_SET_NAME_BT3 = 0x01
 } rf_set_name_t;
 
-__code const char *rf_bt5_name = "SMK BT5.0";
-__code const char *rf_bt3_name = "SMK BT3.0";
+static const __code char rf_bt5_name[] = "SMK BT5.0";
+static const __code char rf_bt3_name[] = "SMK BT3.0";
 
 __xdata uint8_t rf_tx_buf[32];
 
-void    rf_send_blank_report();
+static __xdata uint8_t kro_prev_active;
+static __xdata uint8_t blanking_pending;
+static __xdata bool    blanking_active;
+
+static __xdata bool mac_mode_compat;
+static __xdata bool byte9_disable;
+
+void rf_set_mac_mode_compat(bool is_mac)
+{
+    mac_mode_compat = is_mac;
+}
+
+void rf_byte9_set_disable(bool on)
+{
+    byte9_disable = on;
+}
+
+static uint8_t compute_byte9(bool curr_active)
+{
+    if (mac_mode_compat) return 0;
+    if (curr_active) return 0;
+    if (byte9_disable) return 0;
+    return 1;
+}
+
 bool    rf_get_status(uint8_t status_bytes[2]);
-void    rf_cmd_01(uint8_t mode, uint8_t pairing);
-void    rf_cmd_02(uint8_t *buffer);
-void    rf_cmd_02_nkro(__xdata uint8_t mods, __xdata uint8_t *nkro_buffer);
+void    rf_set_link_mode(uint8_t mode, uint8_t pairing);
+bool    rf_send_kro_report(uint8_t *buffer);
+void    rf_send_nkro_report(__xdata uint8_t mods, __xdata uint8_t *nkro_buffer);
 void    rf_cmd_03(uint8_t param);
 void    rf_cmd_04();
-void    rf_cmd_05(uint16_t consumer, uint16_t system);
+void    rf_send_consumer_system(uint16_t consumer, uint16_t system);
 void    rf_cmd_06(uint8_t param);
-void    rf_cmd_07(uint8_t param);
-void    rf_cmd_08(uint8_t type, char *name);
-void    rf_cmd_0a();
-void    rf_cmd_0b();
-void    rf_cmd_0c();
+void    rf_prepare_sleep(uint8_t param);
+void    rf_set_bt_name(uint8_t type, char *name);
+void    rf_query_status();
+void    rf_wake_from_sleep();
+void    rf_wake_nudge();
 void    rf_fetch_4();
 uint8_t checksum(uint8_t *data, int len);
 
@@ -43,63 +68,71 @@ void rf_init()
 {
     __xdata uint8_t status_bytes[2];
 
-    rf_cmd_0c();
-    delay_ms(6);
-    rf_get_status(status_bytes);
-    delay_us(200);
-    rf_cmd_08(RF_SET_NAME_BT5, rf_bt5_name);
-    delay_ms(12);
-    rf_cmd_04();
-    delay_ms(32);
-    rf_cmd_08(RF_SET_NAME_BT3, rf_bt3_name);
-    delay_ms(12);
-    rf_cmd_04();
-    delay_ms(30);
-    rf_cmd_01(RF_MODE_2_4G, RF_PAIRING_OFF);
+    delay_ms(255);
+    delay_ms(255);
+    delay_ms(255);
+    delay_ms(255);
+    delay_ms(255);
+    delay_ms(255);
+
+    for (uint8_t tries = 10; tries > 0; tries--) {
+        rf_wake_nudge();
+        delay_ms(tries);
+        if (rf_get_status(status_bytes) && (status_bytes[0] & 0x80)) {
+            break;
+        }
+    }
+
+    rf_set_bt_name(RF_SET_NAME_BT5, rf_bt5_name);
+    delay_ms(50);
+    rf_set_bt_name(RF_SET_NAME_BT3, rf_bt3_name);
+    delay_ms(5);
+
+    rf_set_link(RF_MODE_2_4G);
+}
+
+void rf_reassert_link(rf_mode_t link)
+{
+    rf_set_link_mode((uint8_t)link, 0);
     delay_ms(20);
-    rf_cmd_01(RF_MODE_2_4G, RF_PAIRING_OFF);
-    delay_ms(15);
-    rf_cmd_05(0, 0);
-    delay_ms(30);
-    rf_send_blank_report();
+    rf_set_link_mode((uint8_t)link, 0);
+}
+
+void rf_factory_reset_bonds(void)
+{
+    rf_cmd_03(2);
+    delay_ms(200);
+    rf_prepare_sleep(0);
+    delay_ms(100);
+    rf_wake_from_sleep();
+    delay_ms(200);
+    rf_init();
+    delay_ms(200);
 }
 
 __xdata uint8_t kro6buffer[6];
 
+static __xdata uint8_t rf_pending_buf[6];
+static __xdata bool    rf_pending;
+
 void rf_send_report(__xdata report_keyboard_t *report)
 {
-    kro6buffer[0] = report->raw[0];
-    kro6buffer[1] = report->raw[2];
-    kro6buffer[2] = report->raw[3];
-    kro6buffer[3] = report->raw[4];
-    kro6buffer[4] = report->raw[5];
-    kro6buffer[5] = report->raw[6];
+    rf_pending_buf[0] = report->raw[0];
+    rf_pending_buf[1] = report->raw[2];
+    rf_pending_buf[2] = report->raw[3];
+    rf_pending_buf[3] = report->raw[4];
+    rf_pending_buf[4] = report->raw[5];
+    rf_pending_buf[5] = report->raw[6];
+    rf_pending        = true;
 
-    bool blank = true;
-    for (__xdata int i = 0; i < 6; i++) {
-        if (kro6buffer[i] != 0) {
-            blank = false;
-        }
-    }
+    rf_send_pending_flush();
+}
 
-    if (blank) {
-        // blanking sequence
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x01;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x01;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x01;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
-    } else {
-        rf_cmd_02(kro6buffer);
+void rf_send_pending_flush(void)
+{
+    if (!rf_pending) return;
+    if (rf_send_kro_report(rf_pending_buf)) {
+        rf_pending = false;
     }
 }
 
@@ -112,26 +145,13 @@ void rf_send_nkro(__xdata report_nkro_t *report)
         }
     }
 
-    dprintf("is blank: %d\r\n", blank); // FIXME: a delay is necessary here
-
     if (blank) {
-        // blanking sequence
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x01;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x01;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x01;
-        rf_cmd_02(kro6buffer);
-        kro6buffer[1] = 0x00;
-        rf_cmd_02(kro6buffer);
+        for (__xdata int i = 0; i < 6; i++) {
+            kro6buffer[i] = 0;
+        }
+        rf_send_kro_report(kro6buffer);
     } else {
-        rf_cmd_02_nkro(report->mods, report->bits);
+        rf_send_nkro_report(report->mods, report->bits);
     }
 }
 
@@ -139,63 +159,175 @@ void rf_send_extra(__xdata report_extra_t *report)
 {
     switch (report->report_id) {
         case REPORT_ID_SYSTEM:
-            rf_cmd_05(0, report->usage);
+            rf_send_consumer_system(0, report->usage);
             break;
         case REPORT_ID_CONSUMER:
-            rf_cmd_05(report->usage, 0);
+            rf_send_consumer_system(report->usage, 0);
             break;
     }
 }
 
-void rf_update_keyboard_state(keyboard_state_t *keyboard)
+bool rf_update_keyboard_state(keyboard_state_t *keyboard)
 {
     __xdata uint8_t status_bytes[2];
-    rf_get_status(status_bytes);
 
-    keyboard->led_state = status_bytes[1] & ((1 << 0) | (1 << 1) | (1 << 2)); // num, caps, scroll
+    if (!rf_get_status(status_bytes)) {
+        return false;
+    }
+
+    if (!(status_bytes[0] & 0x80)) {
+        rf_wake_nudge();
+    }
+
+    keyboard->battery_level = status_bytes[0] & 0x07;
+
+    keyboard->led_state = status_bytes[1] & ((1 << 0) | (1 << 1) | (1 << 2));
+    keyboard->connected = (status_bytes[1] >> 3) & 1;
+    keyboard->paired    = (status_bytes[1] >> 4) & 1;
+    keyboard->low_power = (status_bytes[1] >> 7) & 1;
 
     uint8_t old_rf_link = keyboard->rf_link;
     keyboard->rf_link   = ((status_bytes[1] & ((1 << 5) | (1 << 6))) >> 5);
     if (old_rf_link != keyboard->rf_link) {
-        dprintf("rf link changed: %d\r\n", keyboard->rf_link);
+        dprintf("rf link changed %02x\r\n", keyboard->rf_link);
+    }
+
+    return true;
+}
+
+#define RF_SUPERVISOR_TICK_INTERVAL 2000u
+#define RF_PAIRING_WINDOW_POLLS     600u
+
+static __xdata uint8_t  commanded_link       = RF_MODE_2_4G;
+static __xdata uint16_t pairing_window_polls = 0;
+
+static __xdata uint16_t supervisor_ticks      = 0;
+static __xdata uint8_t  supervisor_was_paired = 0;
+
+void rf_link_supervisor(keyboard_state_t *keyboard)
+{
+    supervisor_ticks++;
+    if (supervisor_ticks < RF_SUPERVISOR_TICK_INTERVAL) {
+        return;
+    }
+    supervisor_ticks = 0;
+
+    supervisor_was_paired = keyboard->paired;
+
+    if (!rf_update_keyboard_state(keyboard)) {
+        return;
+    }
+
+    if (keyboard->paired && !supervisor_was_paired) {
+        pairing_window_polls = 0;
+        rf_reassert_link((rf_mode_t)commanded_link);
+        return;
+    }
+
+    if (pairing_window_polls != 0) {
+        pairing_window_polls--;
+        return;
+    }
+
+    if ((!keyboard->connected && !keyboard->paired) || (keyboard->rf_link != commanded_link)) {
+        rf_set_link_mode(commanded_link, 0);
     }
 }
 
 void rf_set_link(rf_mode_t link)
 {
-    rf_cmd_01(link, 0);
+    commanded_link = (uint8_t)link;
+    rf_set_link_mode(link, 0);
+    delay_ms(20);
+    rf_set_link_mode(link, 0);
 }
 
-void rf_send_blank_report()
+void rf_apply_usb_mode(void)
 {
-    const uint8_t len = 32;
+    rf_cmd_06(1);
+    delay_ms(20);
+    rf_cmd_06(1);
+}
 
-    rf_tx_buf[0] = MAGIC_BYTE;
-    rf_tx_buf[1] = len - 3;
-    rf_tx_buf[2] = CMD_REPORT;
-    for (int i = 3; i < 31; i++) {
-        rf_tx_buf[i] = 0x00;
+static __xdata bool lazy_init_pending;
+
+void rf_kbd_lazy_state_init(void)
+{
+    lazy_init_pending = true;
+    kro_prev_active   = 0;
+    blanking_pending  = 0;
+}
+
+void rf_blanking_tick(void)
+{
+    if (blanking_pending == 0) {
+        return;
     }
 
-    rf_tx_buf[31] = checksum(rf_tx_buf, len - 1);
+    static __xdata uint8_t phantom_buf[6] = {0, 0x01, 0, 0, 0, 0};
+    static __xdata uint8_t blank_buf[6]   = {0, 0, 0, 0, 0, 0};
+    uint8_t               *buf            = ((blanking_pending & 1) == 0) ? phantom_buf : blank_buf;
 
-    bb_spi_xfer(rf_tx_buf, len);
+    blanking_pending--;
+
+    blanking_active = true;
+    rf_send_kro_report(buf);
+    blanking_active = false;
+}
+
+static __xdata uint8_t pairing_status_bytes[2];
+static __xdata uint8_t pairing_paired_now;
+
+void rf_set_link_pairing(rf_mode_t link, __xdata keyboard_state_t *keyboard)
+{
+    commanded_link = (uint8_t)link;
+
+    rf_set_link_mode(link, 1);
+
+    pairing_paired_now = 0;
+    delay_ms(100);
+    for (uint8_t tries = 10; tries > 0; tries--) {
+        rf_wake_nudge();
+        delay_ms(10);
+        if (rf_get_status(pairing_status_bytes) && (pairing_status_bytes[0] & 0x80)) {
+            keyboard->battery_level = pairing_status_bytes[0] & 0x07;
+            keyboard->led_state     = pairing_status_bytes[1] & ((1 << 0) | (1 << 1) | (1 << 2));
+            keyboard->connected     = (pairing_status_bytes[1] >> 3) & 1;
+            keyboard->paired        = (pairing_status_bytes[1] >> 4) & 1;
+            keyboard->low_power     = (pairing_status_bytes[1] >> 7) & 1;
+            keyboard->rf_link       = ((pairing_status_bytes[1] & ((1 << 5) | (1 << 6))) >> 5);
+            if (keyboard->paired) {
+                pairing_paired_now = 1;
+                break;
+            }
+        }
+        delay_ms(20);
+    }
+
+    if (pairing_paired_now) {
+        delay_ms(50);
+        rf_reassert_link(link);
+    } else {
+        pairing_window_polls = RF_PAIRING_WINDOW_POLLS;
+    }
 }
 
 bool rf_get_status(uint8_t status_bytes[2])
 {
     const uint8_t len = 4;
 
-    rf_cmd_0a();
+    rf_query_status();
     delay_us(100);
     rf_fetch_4();
 
     if (rf_tx_buf[0] != 0xBB) {
+        rf_wake_nudge();
         return false;
     }
 
     uint8_t expected_sum = checksum(rf_tx_buf + 2, len - 2);
     if (rf_tx_buf[1] != expected_sum) {
+        rf_wake_nudge();
         return false;
     }
 
@@ -221,10 +353,22 @@ void rf_fetch_4()
     rf_tx_buf[2] = 0xff;
     rf_tx_buf[3] = 0xff;
 
-    bb_spi_xfer(rf_tx_buf, 4);
+    bb_spi_recv(rf_tx_buf, 4);
 }
 
-void rf_cmd_01(uint8_t mode, uint8_t pairing)
+#define RF_SEND_MAX_ATTEMPTS 5
+
+static bool rf_send_or_retry(uint8_t *buf, int len)
+{
+    for (uint8_t attempt = 0; attempt < RF_SEND_MAX_ATTEMPTS; attempt++) {
+        if (bb_spi_xfer(buf, len)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void rf_set_link_mode(uint8_t mode, uint8_t pairing)
 {
     const uint8_t len = 6;
 
@@ -239,9 +383,29 @@ void rf_cmd_01(uint8_t mode, uint8_t pairing)
     bb_spi_xfer(rf_tx_buf, 6);
 }
 
-void rf_cmd_02(uint8_t *buffer)
+#define BLANKING_COUNT_AFTER_RELEASE 6
+
+static void rf_kro_post_send_blanking(bool curr_active)
+{
+    if (blanking_active) {
+        return;
+    }
+    if (curr_active) {
+        blanking_pending = 0;
+    } else if (kro_prev_active) {
+        blanking_pending = BLANKING_COUNT_AFTER_RELEASE;
+    }
+}
+
+bool rf_send_kro_report(uint8_t *buffer)
 {
     const uint8_t len = 32;
+
+    static __xdata uint8_t empty_buf[6] = {0, 0, 0, 0, 0, 0};
+    if (lazy_init_pending) {
+        lazy_init_pending = false;
+        buffer            = empty_buf;
+    }
 
     rf_tx_buf[0] = MAGIC_BYTE;
     rf_tx_buf[1] = len - 3;
@@ -252,18 +416,36 @@ void rf_cmd_02(uint8_t *buffer)
     rf_tx_buf[6] = buffer[3];
     rf_tx_buf[7] = buffer[4];
     rf_tx_buf[8] = buffer[5];
-    rf_tx_buf[9] = 0x00; // 0x00 or 0x01
 
-    for (int i = 10; i < 31; i++) { // FIXME: NKRO bytes are blanked out until they are implemented
+    uint8_t active = 0;
+    for (__xdata int i = 0; i < 6; i++) {
+        if (buffer[i] != 0) {
+            active = 1;
+            break;
+        }
+    }
+    rf_tx_buf[9] = compute_byte9(active);
+
+    for (int i = 10; i < 31; i++) {
         rf_tx_buf[i] = 0x00;
+    }
+    for (int j = 1; j <= 5; j++) {
+        uint8_t kc = buffer[j];
+        if (kc != 0 && (kc >> 3) < 16) {
+            rf_tx_buf[10 + (kc >> 3)] |= (uint8_t)(1u << (kc & 7));
+        }
     }
 
     rf_tx_buf[31] = checksum(rf_tx_buf, len - 1);
 
-    bb_spi_xfer(rf_tx_buf, len);
+    const bool ack = rf_send_or_retry(rf_tx_buf, len);
+
+    rf_kro_post_send_blanking(active);
+    kro_prev_active = active;
+    return ack;
 }
 
-void rf_cmd_02_nkro(__xdata uint8_t mods, __xdata uint8_t *nkro_buffer)
+void rf_send_nkro_report(__xdata uint8_t mods, __xdata uint8_t *nkro_buffer)
 {
     const uint8_t len = 32;
 
@@ -278,7 +460,16 @@ void rf_cmd_02_nkro(__xdata uint8_t mods, __xdata uint8_t *nkro_buffer)
     rf_tx_buf[7] = 0x00;
     rf_tx_buf[8] = 0x00;
 
-    rf_tx_buf[9] = 0x00; // 0x00 or 0x01
+    uint8_t active = (mods != 0);
+    if (!active) {
+        for (__xdata int i = 0; i < 20; i++) {
+            if (nkro_buffer[i] != 0) {
+                active = 1;
+                break;
+            }
+        }
+    }
+    rf_tx_buf[9] = compute_byte9(active);
 
     rf_tx_buf[10] = nkro_buffer[0];
     rf_tx_buf[11] = nkro_buffer[1];
@@ -305,10 +496,13 @@ void rf_cmd_02_nkro(__xdata uint8_t mods, __xdata uint8_t *nkro_buffer)
 
     rf_tx_buf[31] = checksum(rf_tx_buf, len - 1);
 
-    bb_spi_xfer(rf_tx_buf, len);
+    rf_send_or_retry(rf_tx_buf, len);
+
+    rf_kro_post_send_blanking(active);
+    kro_prev_active = active;
 }
 
-void rf_cmd_03(uint8_t param) // ?? or 0x02
+void rf_cmd_03(uint8_t param)
 {
     const uint8_t len = 6;
 
@@ -336,7 +530,7 @@ void rf_cmd_04()
     bb_spi_xfer(rf_tx_buf, 4);
 }
 
-void rf_cmd_05(uint16_t consumer, uint16_t system)
+void rf_send_consumer_system(uint16_t consumer, uint16_t system)
 {
     const uint8_t len = 14;
 
@@ -356,7 +550,7 @@ void rf_cmd_05(uint16_t consumer, uint16_t system)
 
     rf_tx_buf[len - 1] = checksum(rf_tx_buf, len - 1);
 
-    bb_spi_xfer(rf_tx_buf, len);
+    rf_send_or_retry(rf_tx_buf, len);
 }
 
 void rf_cmd_06(uint8_t param) // 0x00 or 0x01
@@ -374,7 +568,7 @@ void rf_cmd_06(uint8_t param) // 0x00 or 0x01
     bb_spi_xfer(rf_tx_buf, len);
 }
 
-void rf_cmd_07(uint8_t param)
+void rf_prepare_sleep(uint8_t param)
 {
     const uint8_t len = 6;
 
@@ -389,7 +583,7 @@ void rf_cmd_07(uint8_t param)
     bb_spi_xfer(rf_tx_buf, len);
 }
 
-void rf_cmd_08(uint8_t type, char *name)
+void rf_set_bt_name(uint8_t type, char *name)
 {
     const uint8_t len = 32;
 
@@ -397,12 +591,17 @@ void rf_cmd_08(uint8_t type, char *name)
     rf_tx_buf[1] = len - 3;
     rf_tx_buf[2] = 0x08;
     rf_tx_buf[3] = type;
-    int i        = 4;
-    while (*name) {
-        rf_tx_buf[4] = *name;
+
+    uint8_t name_len = 0;
+    int     i        = 5;
+    while (*name && i < (len - 1)) {
+        rf_tx_buf[i] = *name;
         name++;
         i++;
+        name_len++;
     }
+    rf_tx_buf[4] = name_len;
+
     for (int j = i; j < (len - 1); j++) {
         rf_tx_buf[j] = 0x00;
     }
@@ -410,9 +609,11 @@ void rf_cmd_08(uint8_t type, char *name)
     rf_tx_buf[len - 1] = checksum(rf_tx_buf, len - 1);
 
     bb_spi_xfer(rf_tx_buf, len);
+    delay_ms(20);
+    rf_cmd_04();
 }
 
-void rf_cmd_0a()
+void rf_query_status()
 {
     const uint8_t len = 6;
 
@@ -427,7 +628,7 @@ void rf_cmd_0a()
     bb_spi_xfer(rf_tx_buf, len);
 }
 
-void rf_cmd_0b()
+void rf_wake_from_sleep()
 {
     const uint8_t len = 6;
 
@@ -442,7 +643,7 @@ void rf_cmd_0b()
     bb_spi_xfer(rf_tx_buf, len);
 }
 
-void rf_cmd_0c()
+void rf_wake_nudge()
 {
     const uint8_t len = 6;
 

--- a/src/platform/bk3632/rf_controller.h
+++ b/src/platform/bk3632/rf_controller.h
@@ -16,5 +16,25 @@ void rf_init();
 void rf_send_report(__xdata report_keyboard_t *report);
 void rf_send_nkro(__xdata report_nkro_t *report);
 void rf_send_extra(__xdata report_extra_t *report);
-void rf_update_keyboard_state(keyboard_state_t *keyboard);
+bool rf_update_keyboard_state(keyboard_state_t *keyboard);
 void rf_set_link(rf_mode_t link);
+void rf_set_link_pairing(rf_mode_t link, __xdata keyboard_state_t *keyboard);
+void rf_factory_reset_bonds(void);
+void rf_link_supervisor(keyboard_state_t *keyboard);
+void rf_reassert_link(rf_mode_t link);
+
+void rf_apply_usb_mode(void);
+
+void rf_set_mac_mode_compat(bool is_mac);
+
+void rf_byte9_set_disable(bool on);
+
+void rf_kbd_lazy_state_init(void);
+
+void rf_send_pending_flush(void);
+
+void rf_blanking_tick(void);
+
+void rf_prepare_sleep(uint8_t param);
+void rf_wake_from_sleep(void);
+void rf_wake_nudge(void);

--- a/src/smk/keyboard.c
+++ b/src/smk/keyboard.c
@@ -7,8 +7,12 @@ __xdata keymap_config_t keymap_config;
 
 void keyboard_init()
 {
-    keyboard_state.led_state = 0x00;
-    keyboard_state.rf_link   = 0x00;
+    keyboard_state.led_state     = 0x00;
+    keyboard_state.rf_link       = 0x00;
+    keyboard_state.battery_level = 0x00;
+    keyboard_state.low_power     = 0x00;
+    keyboard_state.connected     = 0x00;
+    keyboard_state.paired        = 0x00;
 
 #ifdef NKRO_ENABLE
     keymap_config.nkro = 1;

--- a/src/smk/keyboard.h
+++ b/src/smk/keyboard.h
@@ -5,6 +5,10 @@
 typedef struct {
     uint8_t led_state;
     uint8_t rf_link;
+    uint8_t battery_level; // 0..7
+    uint8_t low_power;
+    uint8_t connected; // 1 when the active RF link has a host paired+connected
+    uint8_t paired;    // 1 when the active RF link has a paired host
 } keyboard_state_t;
 
 typedef struct {


### PR DESCRIPTION
Adds link selection, a status supervisor that re-asserts a dead or mismatched link, one-shot pairing per long-press, and post-release blanking so a dropped release cannot latch a key.