### PR TITLE
Fix the release build and cover it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         nkro: [enabled, disabled]
+        buildtype: [debug, release]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -24,13 +25,13 @@ jobs:
         name: smk
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
     - name: Setup
-      run: nix develop --command meson setup build -Dnkro=${{ matrix.nkro }}
+      run: nix develop --command meson setup build -Dnkro=${{ matrix.nkro }} -Dbuildtype=${{ matrix.buildtype }}
     - name: Build
       run: nix develop --command meson compile -C build
     - name: Archive code coverage results
       uses: actions/upload-artifact@v7
       with:
-        name: smk-${{ matrix.nkro == 'enabled' && 'nkro' || '6kro' }}
+        name: smk-${{ matrix.buildtype }}-${{ matrix.nkro == 'enabled' && 'nkro' || '6kro' }}
         path: build/*.hex
 
   sim-tests:

--- a/meson.build
+++ b/meson.build
@@ -168,8 +168,6 @@ sdar = find_program('sdar', required : true)
 packihx = find_program('packihx', required : true)
 sinowisp = find_program('sinowisp', required : true)
 
-sdcc_libdir = fs.parent(fs.parent(cc.full_path())) / 'share/sdcc/lib/large-stack-auto'
-
 py = find_program('python3', required : true)
 sdcc_compile = join_paths(meson.current_source_dir(), 'utils/sdcc_compile.py')
 
@@ -315,7 +313,7 @@ foreach part : parts
             input : rel_main,
             output : ihx_smk_target_name,
             depends: [lib_user],
-            command : [cc, cc_args, '--lib-path', sdcc_libdir, '-o', '@OUTPUT@', '@INPUT@', '-l' + lib_user.full_path()],
+            command : [cc, cc_args, '-o', '@OUTPUT@', '@INPUT@', '-l' + lib_user.full_path()],
         )
 
         # Overlay/interrupt-safety gate: reads the just-linked .map + per-module .asm

--- a/src/keyboards/nuphy-air60/user_init.c
+++ b/src/keyboards/nuphy-air60/user_init.c
@@ -3,6 +3,12 @@
 #include "pwm.h"
 #include "gpio.h"
 
+// UART TXD is CONN_MODE_SWITCH's pin (P5.5): the slider and a UART sink cannot
+// coexist without remapping one of them.
+#ifdef DEBUG_SINK_UART
+#    error "nuphy-air60: DEBUG_SINK_UART is unusable here - TXD collides with CONN_MODE_SWITCH"
+#endif
+
 #define PWM_PERD 0x0100
 
 #define PWM_DUTY1 (uint16_t)0
@@ -46,9 +52,6 @@ void user_gpio_init()
 
     P5PCR = (uint8_t)(KB_R3_P5_3 | KB_R4_P5_4 | CONN_MODE_SWITCH_P5_5 | OS_MODE_SWITCH_P5_6);
     P7PCR = (uint8_t)(KB_R0_P7_1 | KB_R1_P7_2 | KB_R2_P7_3);
-
-    if (DEBUG) {
-    }
     P7 |= RF_BB_SPI_CS_P7_4;
     P4 |= RF_BB_SPI_SCK_P4_7;
     P0 |= (RF_BB_SPI_MOSI_P0_7 | RF_BB_SPI_MOT_P0_5);

--- a/src/platform/bk3632/rf_controller.c
+++ b/src/platform/bk3632/rf_controller.c
@@ -189,11 +189,9 @@ bool rf_update_keyboard_state(keyboard_state_t *keyboard)
     keyboard->paired    = (status_bytes[1] >> 4) & 1;
     keyboard->low_power = (status_bytes[1] >> 7) & 1;
 
-    uint8_t old_rf_link = keyboard->rf_link;
-    keyboard->rf_link   = ((status_bytes[1] & ((1 << 5) | (1 << 6))) >> 5);
-    if (old_rf_link != keyboard->rf_link) {
-        dprintf("rf link changed %02x\r\n", keyboard->rf_link);
-    }
+    const uint8_t old_rf_link = keyboard->rf_link;
+    keyboard->rf_link         = ((status_bytes[1] & ((1 << 5) | (1 << 6))) >> 5);
+    dprintf_if(old_rf_link != keyboard->rf_link, "rf link changed %02x\r\n", keyboard->rf_link);
 
     return true;
 }

--- a/src/smk/debug.h
+++ b/src/smk/debug.h
@@ -2,7 +2,18 @@
 
 #include "console.h"
 
-#define dprintf(...)                            \
-    do {                                        \
-        if (DEBUG) console_printf(__VA_ARGS__); \
-    } while (0)
+#if DEBUG == 1
+#    define dprintf(...) console_printf(__VA_ARGS__)
+#else
+#    define dprintf(...) ((void)0)
+#endif
+
+// Use instead of an `if` around dprintf: an empty branch trips --Werror.
+#if DEBUG == 1
+#    define dprintf_if(cond, ...)           \
+        do {                                \
+            if (cond) dprintf(__VA_ARGS__); \
+        } while (0)
+#else
+#    define dprintf_if(cond, ...) ((void)(cond))
+#endif


### PR DESCRIPTION
Gates dprintf at the preprocessor so release builds stop failing on an undefined DEBUG, adds buildtype to the CI matrix, and drops a --lib-path override that no longer has any effect.