### PR TITLE
Name magic register values and cut comments to what the code cannot say

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         };
 
         # uCsim (the SDCC 8051 simulator) patched so the SH68F90's USB interrupt
-        # (vector 7 @ 0x3B) is a real, registered interrupt source — stock uCsim
+        # (vector 7 @ 0x3B) is a real, registered interrupt source - stock uCsim
         # only knows the classic 8051 vectors. Lets us drive usb_interrupt_handler
         # in simulation with faithful vectoring/stack/nesting.
         ucsim-sh68f90 = pkgs.stdenv.mkDerivation {

--- a/meson.build
+++ b/meson.build
@@ -168,6 +168,7 @@ sdar = find_program('sdar', required : true)
 packihx = find_program('packihx', required : true)
 sinowisp = find_program('sinowisp', required : true)
 
+# SDCC's -M family is deps-only, so a wrapper writes the depfile ninja needs.
 py = find_program('python3', required : true)
 sdcc_compile = join_paths(meson.current_source_dir(), 'utils/sdcc_compile.py')
 
@@ -183,6 +184,7 @@ host_cc = find_program('cc', 'gcc', required : true)
 gen_led_geometry = join_paths(meson.current_build_dir(), 'led_geometry_gen')
 run_command(host_cc, '-O2', '-o', gen_led_geometry, join_paths(meson.current_source_dir(), 'utils/led_geometry_gen.c'), check : true)
 
+# Host-side reader for the HID debug console; built with the host compiler.
 executable(
     'smk-console',
     'tools/smk-console.c',

--- a/src/keyboards/eyooso-z11/layouts/default/indicators.c
+++ b/src/keyboards/eyooso-z11/layouts/default/indicators.c
@@ -1,6 +1,7 @@
 #include "indicators.h"
 #include "sh68f90a.h"
 #include "kbdef.h"
+#include "gpio.h"
 #include "pwm.h"
 #include "settings.h"
 #include "led_effect.h"
@@ -9,10 +10,8 @@
 #define LED_ROWS MATRIX_ROWS
 #define LED_COLS MATRIX_COLS
 
-// Phase increment per full framebuffer sweep. Larger = faster.
 #define LED_PHASE_SPEED 4
 
-// 8-bit framebuffer brightness -> 10-bit column PWM duty (0 = full on, 0x400 = off)
 #define LED_DUTY(v) (uint16_t)(0x0400u - ((uint16_t)(v) << 2))
 
 #define LED_ALL_ROWS (uint8_t)(LED_R0_P6_1 | LED_R1_P6_2 | LED_R2_P6_3 | LED_R3_P6_4 | LED_R4_P6_5)
@@ -40,7 +39,6 @@ void indicators_start()
     regen_row = 0;
     regen_col = 0;
 
-    // restore the last saved effect (defaults to radial on a fresh flash)
     user_settings.led_effect = FX_RADIAL;
     settings_load();
     if (user_settings.led_effect > FX_OFF) {
@@ -52,7 +50,6 @@ void indicators_start()
 
 void indicators_next_effect()
 {
-    // OFF -> FX_RADIAL -> ... -> FX_SOLID -> OFF -> ...
     if (++user_settings.led_effect > FX_OFF) {
         user_settings.led_effect = 0;
     }
@@ -68,8 +65,7 @@ void indicators_factory_reset()
 
 void indicators_pre_update()
 {
-    // disable every LED row (active-low: high = off); the step re-enables one
-    P6 |= LED_ALL_ROWS;
+    GPIO_HIGH(6, LED_ALL_ROWS);
 
     indicators_pwm_disable();
 }
@@ -78,18 +74,14 @@ bool indicators_update_step(keyboard_state_t *keyboard, uint8_t current_step)
 {
     current_step;
 
-    // caps-lock indicator works regardless of backlight state
     LED_CAPS = !(keyboard->led_state & (1 << 1));
 
     if (user_settings.led_effect >= FX_OFF) {
-        // backlight off: pre_update already disabled every row, so nothing lights
         return false;
     }
 
-    // regenerate one LED of the framebuffer per ISR, spreading the work out
     led_regen_one();
 
-    // light one row this substep, with per-column brightness from the framebuffer
     led_enable_row();
     led_set_columns();
 
@@ -102,7 +94,6 @@ bool indicators_update_step(keyboard_state_t *keyboard, uint8_t current_step)
 
 void indicators_post_update()
 {
-    // clear pwm isr flag
     PWM00CON &= ~(1 << 5);
 
     indicators_pwm_enable();

--- a/src/keyboards/eyooso-z11/user_init.c
+++ b/src/keyboards/eyooso-z11/user_init.c
@@ -35,18 +35,17 @@ void user_gpio_init()
 
     DRVCON = DRVCON_LOCK;
 
-    P0CR = (uint8_t)(LED_CAPS_P0_3);
-    P1CR = (uint8_t)(KB_C0_P1_4 | KB_C1_P1_5);
-    P2CR = (uint8_t)(KB_C2_P2_0 | KB_C3_P2_1 | KB_C4_P2_2 | KB_C5_P2_3 | KB_C6_P2_4 | KB_C7_P2_5);
-    P3CR = (uint8_t)(KB_C8_P3_0 | KB_C9_P3_1 | KB_C10_P3_2 | KB_C11_P3_3 | KB_C12_P3_4 | KB_C13_P3_5);
-    P6CR = (uint8_t)(LED_R0_P6_1 | LED_R1_P6_2 | LED_R2_P6_3 | LED_R3_P6_4 | LED_R4_P6_5);
+    GPIO_DIR_WRITE(0, (uint8_t)(LED_CAPS_P0_3));
+    GPIO_DIR_WRITE(1, (uint8_t)(KB_C0_P1_4 | KB_C1_P1_5));
+    GPIO_DIR_WRITE(2, (uint8_t)(KB_C2_P2_0 | KB_C3_P2_1 | KB_C4_P2_2 | KB_C5_P2_3 | KB_C6_P2_4 | KB_C7_P2_5));
+    GPIO_DIR_WRITE(3, (uint8_t)(KB_C8_P3_0 | KB_C9_P3_1 | KB_C10_P3_2 | KB_C11_P3_3 | KB_C12_P3_4 | KB_C13_P3_5));
+    GPIO_DIR_WRITE(6, (uint8_t)(LED_R0_P6_1 | LED_R1_P6_2 | LED_R2_P6_3 | LED_R3_P6_4 | LED_R4_P6_5));
 
-    P5PCR = (uint8_t)(KB_R3_P5_3 | KB_R4_P5_4);
-    // P6PCR  = (uint8_t)(LED_R0_P6_1 | LED_R1_P6_2 | LED_R2_P6_3 | LED_R3_P6_4 | LED_R4_P6_5);
-    P7PCR = (uint8_t)(KB_R0_P7_1 | KB_R1_P7_2 | KB_R2_P7_3);
+    GPIO_PULLUP_WRITE(5, (uint8_t)(KB_R3_P5_3 | KB_R4_P5_4));
+    GPIO_PULLUP_WRITE(7, (uint8_t)(KB_R0_P7_1 | KB_R1_P7_2 | KB_R2_P7_3));
 
-    P0 = (uint8_t)(LED_CAPS_P0_3);
-    P6 = (uint8_t)(LED_R0_P6_1 | LED_R1_P6_2 | LED_R2_P6_3 | LED_R3_P6_4 | LED_R4_P6_5);
+    GPIO_WRITE(0, LED_CAPS_P0_3);
+    GPIO_WRITE(6, LED_R0_P6_1 | LED_R1_P6_2 | LED_R2_P6_3 | LED_R3_P6_4 | LED_R4_P6_5);
 }
 
 void user_pwm_init()

--- a/src/keyboards/eyooso-z11/user_matrix.c
+++ b/src/keyboards/eyooso-z11/user_matrix.c
@@ -1,4 +1,5 @@
 #include "kbdef.h"
+#include "gpio.h"
 #include "user_matrix.h"
 
 #define KB_C_P1_MASK (uint8_t)(KB_C0_P1_4 | KB_C1_P1_5)
@@ -7,9 +8,9 @@
 
 void user_matrix_cols_deselect_all(void)
 {
-    P1 |= KB_C_P1_MASK;
-    P2 |= KB_C_P2_MASK;
-    P3 |= KB_C_P3_MASK;
+    GPIO_HIGH(1, KB_C_P1_MASK);
+    GPIO_HIGH(2, KB_C_P2_MASK);
+    GPIO_HIGH(3, KB_C_P3_MASK);
 }
 
 void user_matrix_col_select(uint8_t col)

--- a/src/keyboards/nuphy-air60/layouts/default/indicators.c
+++ b/src/keyboards/nuphy-air60/layouts/default/indicators.c
@@ -1,5 +1,6 @@
 #include "indicators.h"
 #include "kbdef.h"
+#include "gpio.h"
 #include "pwm.h"
 #include "settings.h"
 #include "tick.h"
@@ -11,19 +12,12 @@
 #    include "rf_controller.h"
 #endif
 
-// The LED matrix follows the key matrix dimensions, so a differently-sized RGB board
-// only needs the right MATRIX_ROWS/MATRIX_COLS (kbdef.h), its geometry parameters in
-// meson.build, plus its own sink/column wiring below.
 #define LED_ROWS MATRIX_ROWS
 #define LED_COLS MATRIX_COLS
 
-// The underglow ("user") LEDs are wired as an extra sink group, scanned as one more
-// row after the key matrix. They mirror the bottom key row so they animate together
-// with whatever effect is active.
 #define LED_UL_ROW    LED_ROWS
 #define LED_SCAN_ROWS (LED_ROWS + 1)
 
-// Defaults / clamps for user_settings.led_speed (phase increment per ~73 Hz sweep).
 #define LED_SPEED_DEFAULT    4
 #define LED_UL_SPEED_DEFAULT 1 // underglow defaults slow - it's ambient
 #define LED_SPEED_MIN        1
@@ -33,7 +27,6 @@
 
 #define BAT_FLASH_SWEEPS 200
 
-// Brightness step for one Fn+Up / Fn+Down press (out of 256 levels).
 #define LED_BRIGHTNESS_DEFAULT 255
 #define LED_BRIGHTNESS_STEP    32
 
@@ -44,7 +37,6 @@
 // DUTY2=0xFF makes "off" subframes glow at full brightness.
 #define LED_DUTY(v) (uint16_t)(v)
 
-// Scale an 8-bit channel by the current brightness (main and underglow are independent).
 #define SCALE_BRI(v)    (uint8_t)(((uint16_t)(uint8_t)(v) * user_settings.led_brightness) >> 8)
 #define SCALE_UL_BRI(v) (uint8_t)(((uint16_t)(uint8_t)(v) * user_settings.ul_brightness) >> 8)
 
@@ -53,8 +45,6 @@ _Static_assert(LED_GEOMETRY_ROWS == LED_ROWS && LED_GEOMETRY_COLS == LED_COLS, "
 
 static uint8_t led_fb[LED_ROWS][3][LED_COLS];
 
-// Separate framebuffer for the underglow ("user") LEDs, since they animate
-// independently of the main backlight.
 static uint8_t led_ul_fb[3][LED_COLS];
 
 static uint8_t led_row;
@@ -81,7 +71,6 @@ static void led_regen_one();
 static void led_enable_sink();
 static bool led_set_columns();
 
-// Sets every field of user_settings to its factory default value.
 void indicators_apply_defaults()
 {
     user_settings.led_effect           = FX_RADIAL;
@@ -140,7 +129,6 @@ void indicators_validate_settings()
         user_settings.ul_speed = LED_SPEED_MAX;
     }
 }
-
 void indicators_init()
 {
     memset(led_fb, 0, sizeof(led_fb));
@@ -164,7 +152,6 @@ void indicators_start()
 
 void indicators_next_effect()
 {
-    // OFF -> FX_RADIAL -> ... -> FX_SOLID -> OFF -> ...
     if (++user_settings.led_effect > FX_OFF) {
         user_settings.led_effect = 0;
     }
@@ -174,7 +161,6 @@ void indicators_next_effect()
 
 void indicators_prev_effect()
 {
-    // OFF <- FX_RADIAL <- ... <- FX_SOLID <- OFF <- ...
     if (user_settings.led_effect == 0) {
         user_settings.led_effect = FX_OFF;
     } else {
@@ -221,9 +207,6 @@ void indicators_speed_down()
 
     settings_mark_dirty();
 }
-
-// Underglow / "user-light" controls. Identical logic to the main backlight ones,
-// but operating on the independent ul_* fields of user_settings.
 
 void indicators_ul_next_effect()
 {
@@ -281,11 +264,11 @@ void indicators_ul_speed_down()
 
 void indicators_pre_update()
 {
-    P0 &= ~(RGB_R2R_P0_2 | RGB_R0B_P0_3 | RGB_R0R_P0_4);
-    P1 &= ~(RGB_ULR_P1_1 | RGB_ULG_P1_2 | RGB_ULB_P1_3);
-    P4 &= ~(RGB_R4B_P4_3 | RGB_R4R_P4_4 | RGB_R3R_P4_5 | RGB_R3B_P4_6);
-    P5 &= ~(RGB_R2B_P5_7);
-    P6 &= ~(RGB_R0G_P6_1 | RGB_R1G_P6_2 | RGB_R2G_P6_3 | RGB_R3G_P6_4 | RGB_R4G_P6_5 | RGB_R1B_P6_6 | RGB_R1R_P6_7);
+    GPIO_LOW(0, (RGB_R2R_P0_2 | RGB_R0B_P0_3 | RGB_R0R_P0_4));
+    GPIO_LOW(1, (RGB_ULR_P1_1 | RGB_ULG_P1_2 | RGB_ULB_P1_3));
+    GPIO_LOW(4, (RGB_R4B_P4_3 | RGB_R4R_P4_4 | RGB_R3R_P4_5 | RGB_R3B_P4_6));
+    GPIO_LOW(5, (RGB_R2B_P5_7));
+    GPIO_LOW(6, (RGB_R0G_P6_1 | RGB_R1G_P6_2 | RGB_R2G_P6_3 | RGB_R3G_P6_4 | RGB_R4G_P6_5 | RGB_R1B_P6_6 | RGB_R1R_P6_7));
 }
 
 void indicators_render()
@@ -312,10 +295,10 @@ bool indicators_update_step(keyboard_state_t *keyboard, uint8_t current_step)
             battery_flash_sweeps--;
         }
         status_pulse_counter++;
-        render_dirty = true;
+        render_dirty = true; // UL/status advanced - repaint the frame
     } else if (anim_ctr == (uint8_t)(LED_ROWS * LED_COLS)) {
         led_phase    = (uint8_t)(led_phase + user_settings.led_speed);
-        render_dirty = true;
+        render_dirty = true; // main effect advanced - repaint the frame
     }
 
     indicators_pwm_disable();
@@ -330,8 +313,8 @@ bool indicators_update_step(keyboard_state_t *keyboard, uint8_t current_step)
     }
 
     if (lit) {
-        led_enable_sink(); // raise this subframe's sink while parked
-        indicators_pwm_enable();
+        led_enable_sink();       // raise this subframe's sink while parked
+        indicators_pwm_enable(); // re-enable last - the selected row lights now
     }
 
     bool frame_wrapped = false;
@@ -354,7 +337,6 @@ void indicators_post_update()
 static void led_regen_one()
 {
     if (regen_row < LED_ROWS) {
-        // -------- MAIN backlight cell --------
         uint8_t rgb[3];
         if (led_effect_rgb((led_effect_t)user_settings.led_effect, regen_row, regen_col, led_phase, user_settings.led_brightness, rgb)) {
             led_fb[regen_row][0][regen_col] = rgb[0];
@@ -431,7 +413,6 @@ static void led_regen_one()
                         h = (uint8_t)(user_led_axis_x(regen_col) + ul_phase);
                         break;
                     case FX_VERTICAL:
-                        // UL is one strip, so vertical = whole strip cycling together
                         h = ul_phase;
                         break;
                     case FX_RADIAL:
@@ -522,7 +503,6 @@ static void led_enable_sink()
 
 static bool led_set_columns()
 {
-    // underglow uses its own framebuffer; key rows use the main one
     __xdata uint8_t *fb = (led_row == LED_UL_ROW) ? led_ul_fb[led_color] : led_fb[led_row][led_color];
 
     uint8_t any = 0;
@@ -588,7 +568,7 @@ void indicators_pwm_enable()
     PWM41CON = PWM_SS;
     PWM42CON = PWM_SS;
 }
-
+// The ~5 ms erase runs with interrupts off, so park the scan and columns across it.
 void settings_save_pre(void)
 {
     tick_pause();

--- a/src/keyboards/nuphy-air60/user_init.c
+++ b/src/keyboards/nuphy-air60/user_init.c
@@ -42,23 +42,24 @@ void user_gpio_init()
 
     DRVCON = DRVCON_LOCK;
 
-    P0CR = (uint8_t)(RGB_R2R_P0_2 | RGB_R0B_P0_3 | RGB_R0R_P0_4);
-    P1CR = (uint8_t)(RGB_ULR_P1_1 | RGB_ULG_P1_2 | RGB_ULB_P1_3 | KB_C15_P1_5);
-    P2CR = (uint8_t)(KB_C14_P2_0 | KB_C13_P2_1 | KB_C12_P2_2 | KB_C11_P2_3 | KB_C10_P2_4 | KB_C9_P2_5);
-    P3CR = (uint8_t)(KB_C8_P3_0 | KB_C7_P3_1 | KB_C6_P3_2 | KB_C5_P3_3 | KB_C4_P3_4 | KB_C3_P3_5);
-    P4CR = (uint8_t)(RGB_R4B_P4_3 | RGB_R4R_P4_4 | RGB_R3R_P4_5 | RGB_R3B_P4_6);
-    P5CR = (uint8_t)(KB_C0_P5_0 | KB_C1_P5_1 | KB_C2_P5_2 | RGB_R2B_P5_7);
-    P6CR = (uint8_t)(RGB_R0G_P6_1 | RGB_R1G_P6_2 | RGB_R2G_P6_3 | RGB_R3G_P6_4 | RGB_R4G_P6_5 | RGB_R1B_P6_6 | RGB_R1R_P6_7);
+    GPIO_DIR_WRITE(0, (uint8_t)(RGB_R2R_P0_2 | RGB_R0B_P0_3 | RGB_R0R_P0_4));
+    GPIO_DIR_WRITE(1, (uint8_t)(RGB_ULR_P1_1 | RGB_ULG_P1_2 | RGB_ULB_P1_3 | KB_C15_P1_5));
+    GPIO_DIR_WRITE(2, (uint8_t)(KB_C14_P2_0 | KB_C13_P2_1 | KB_C12_P2_2 | KB_C11_P2_3 | KB_C10_P2_4 | KB_C9_P2_5));
+    GPIO_DIR_WRITE(3, (uint8_t)(KB_C8_P3_0 | KB_C7_P3_1 | KB_C6_P3_2 | KB_C5_P3_3 | KB_C4_P3_4 | KB_C3_P3_5));
+    GPIO_DIR_WRITE(4, (uint8_t)(RGB_R4B_P4_3 | RGB_R4R_P4_4 | RGB_R3R_P4_5 | RGB_R3B_P4_6));
+    GPIO_DIR_WRITE(5, (uint8_t)(KB_C0_P5_0 | KB_C1_P5_1 | KB_C2_P5_2 | RGB_R2B_P5_7));
+    GPIO_DIR_WRITE(6, (uint8_t)(RGB_R0G_P6_1 | RGB_R1G_P6_2 | RGB_R2G_P6_3 | RGB_R3G_P6_4 | RGB_R4G_P6_5 | RGB_R1B_P6_6 | RGB_R1R_P6_7));
 
-    P5PCR = (uint8_t)(KB_R3_P5_3 | KB_R4_P5_4 | CONN_MODE_SWITCH_P5_5 | OS_MODE_SWITCH_P5_6);
-    P7PCR = (uint8_t)(KB_R0_P7_1 | KB_R1_P7_2 | KB_R2_P7_3);
-    P7 |= RF_BB_SPI_CS_P7_4;
-    P4 |= RF_BB_SPI_SCK_P4_7;
-    P0 |= (RF_BB_SPI_MOSI_P0_7 | RF_BB_SPI_MOT_P0_5);
+    GPIO_PULLUP_WRITE(5, (uint8_t)(KB_R3_P5_3 | KB_R4_P5_4 | CONN_MODE_SWITCH_P5_5 | OS_MODE_SWITCH_P5_6));
+    GPIO_PULLUP_WRITE(7, (uint8_t)(KB_R0_P7_1 | KB_R1_P7_2 | KB_R2_P7_3));
 
-    P0PCR |= (RF_BB_SPI_MISO_P0_6 | RF_BB_SPI_MOSI_P0_7 | RF_BB_SPI_MOT_P0_5);
-    P4PCR |= (RF_BB_SPI_ACK_P4_2 | RF_BB_SPI_SCK_P4_7);
-    P7PCR |= RF_BB_SPI_CS_P7_4;
+    // bb_spi drives these open-drain: latch high, and leave PxCR to its per-cycle toggling.
+    GPIO_HIGH(7, RF_BB_SPI_CS_P7_4);
+    GPIO_HIGH(4, RF_BB_SPI_SCK_P4_7);
+    GPIO_HIGH(0, (RF_BB_SPI_MOSI_P0_7 | RF_BB_SPI_MOT_P0_5));
+    GPIO_PULLUP_ON(0, (RF_BB_SPI_MISO_P0_6 | RF_BB_SPI_MOSI_P0_7 | RF_BB_SPI_MOT_P0_5));
+    GPIO_PULLUP_ON(4, (RF_BB_SPI_ACK_P4_2 | RF_BB_SPI_SCK_P4_7));
+    GPIO_PULLUP_ON(7, RF_BB_SPI_CS_P7_4);
 }
 
 void user_pwm_init()

--- a/src/keyboards/nuphy-air60/user_matrix.c
+++ b/src/keyboards/nuphy-air60/user_matrix.c
@@ -1,4 +1,5 @@
 #include "kbdef.h"
+#include "gpio.h"
 #include "user_matrix.h"
 
 #define KB_C_P1_MASK (uint8_t)(KB_C15_P1_5)
@@ -8,30 +9,30 @@
 
 void user_matrix_cols_deselect_all(void)
 {
-    P1 |= KB_C_P1_MASK;
-    P2 |= KB_C_P2_MASK;
-    P3 |= KB_C_P3_MASK;
-    P5 |= KB_C_P5_MASK;
+    GPIO_HIGH(1, KB_C_P1_MASK);
+    GPIO_HIGH(2, KB_C_P2_MASK);
+    GPIO_HIGH(3, KB_C_P3_MASK);
+    GPIO_HIGH(5, KB_C_P5_MASK);
 }
 
 void user_matrix_scan_pre(void)
 {
-    P1CR |= KB_C_P1_MASK;
-    P2CR |= KB_C_P2_MASK;
-    P3CR |= KB_C_P3_MASK;
-    P5CR |= KB_C_P5_MASK;
+    GPIO_OUTPUT(1, KB_C_P1_MASK);
+    GPIO_OUTPUT(2, KB_C_P2_MASK);
+    GPIO_OUTPUT(3, KB_C_P3_MASK);
+    GPIO_OUTPUT(5, KB_C_P5_MASK);
 }
 
 void user_matrix_scan_post(void)
 {
-    P1PCR &= (uint8_t)~KB_C_P1_MASK;
-    P1CR &= (uint8_t)~KB_C_P1_MASK;
-    P2PCR &= (uint8_t)~KB_C_P2_MASK;
-    P2CR &= (uint8_t)~KB_C_P2_MASK;
-    P3PCR &= (uint8_t)~KB_C_P3_MASK;
-    P3CR &= (uint8_t)~KB_C_P3_MASK;
-    P5PCR &= (uint8_t)~KB_C_P5_MASK;
-    P5CR &= (uint8_t)~KB_C_P5_MASK;
+    GPIO_PULLUP_OFF(1, KB_C_P1_MASK);
+    GPIO_INPUT(1, KB_C_P1_MASK);
+    GPIO_PULLUP_OFF(2, KB_C_P2_MASK);
+    GPIO_INPUT(2, KB_C_P2_MASK);
+    GPIO_PULLUP_OFF(3, KB_C_P3_MASK);
+    GPIO_INPUT(3, KB_C_P3_MASK);
+    GPIO_PULLUP_OFF(5, KB_C_P5_MASK);
+    GPIO_INPUT(5, KB_C_P5_MASK);
 }
 
 void user_matrix_col_select(uint8_t col) // active-low: drive LOW
@@ -149,9 +150,9 @@ uint8_t user_matrix_read_rows(void)
 
 void user_matrix_sinks_off(void)
 {
-    P0 &= ~(uint8_t)(RGB_R2R_P0_2 | RGB_R0B_P0_3 | RGB_R0R_P0_4);
-    P1 &= ~(uint8_t)(RGB_ULR_P1_1 | RGB_ULG_P1_2 | RGB_ULB_P1_3);
-    P4 &= ~(uint8_t)(RGB_R4B_P4_3 | RGB_R4R_P4_4 | RGB_R3R_P4_5 | RGB_R3B_P4_6);
-    P5 &= ~(uint8_t)(RGB_R2B_P5_7);
-    P6 &= ~(uint8_t)(RGB_R0G_P6_1 | RGB_R1G_P6_2 | RGB_R2G_P6_3 | RGB_R3G_P6_4 | RGB_R4G_P6_5 | RGB_R1B_P6_6 | RGB_R1R_P6_7);
+    GPIO_LOW(0, RGB_R2R_P0_2 | RGB_R0B_P0_3 | RGB_R0R_P0_4);
+    GPIO_LOW(1, RGB_ULR_P1_1 | RGB_ULG_P1_2 | RGB_ULB_P1_3);
+    GPIO_LOW(4, RGB_R4B_P4_3 | RGB_R4R_P4_4 | RGB_R3R_P4_5 | RGB_R3B_P4_6);
+    GPIO_LOW(5, RGB_R2B_P5_7);
+    GPIO_LOW(6, RGB_R0G_P6_1 | RGB_R1G_P6_2 | RGB_R2G_P6_3 | RGB_R3G_P6_4 | RGB_R4G_P6_5 | RGB_R1B_P6_6 | RGB_R1R_P6_7);
 }

--- a/src/platform/bb_spi.c
+++ b/src/platform/bb_spi.c
@@ -1,5 +1,6 @@
 #include "bb_spi.h"
 #include "kbdef.h"
+#include "gpio.h"
 #include "delay.h"
 
 #define _nop_() __asm nop __endasm
@@ -9,27 +10,27 @@ uint8_t bb_spi_xfer_byte(uint8_t data);
 #define RF_BB_SPI_ACK_POLL_MAX 50
 #define RF_BB_SPI_ACK_POLL_US  3
 
-#define MOT_DRIVE_LOW()    \
-    do {                   \
-        RF_BB_SPI_MOT = 0; \
-        P0CR |= _P0_5;     \
-        RF_BB_SPI_MOT = 0; \
+#define MOT_DRIVE_LOW()                     \
+    do {                                    \
+        RF_BB_SPI_MOT = 0;                  \
+        GPIO_OUTPUT(0, RF_BB_SPI_MOT_P0_5); \
+        RF_BB_SPI_MOT = 0;                  \
     } while (0)
-#define MOT_RELEASE_HIGH()       \
-    do {                         \
-        P0CR &= (uint8_t)~_P0_5; \
-        RF_BB_SPI_MOT = 1;       \
+#define MOT_RELEASE_HIGH()                 \
+    do {                                   \
+        GPIO_INPUT(0, RF_BB_SPI_MOT_P0_5); \
+        RF_BB_SPI_MOT = 1;                 \
     } while (0)
-#define CS_DRIVE_LOW()    \
-    do {                  \
-        RF_BB_SPI_CS = 0; \
-        P7CR |= _P7_4;    \
-        RF_BB_SPI_CS = 0; \
+#define CS_DRIVE_LOW()                     \
+    do {                                   \
+        RF_BB_SPI_CS = 0;                  \
+        GPIO_OUTPUT(7, RF_BB_SPI_CS_P7_4); \
+        RF_BB_SPI_CS = 0;                  \
     } while (0)
-#define CS_RELEASE_HIGH()        \
-    do {                         \
-        P7CR &= (uint8_t)~_P7_4; \
-        RF_BB_SPI_CS = 1;        \
+#define CS_RELEASE_HIGH()                 \
+    do {                                  \
+        GPIO_INPUT(7, RF_BB_SPI_CS_P7_4); \
+        RF_BB_SPI_CS = 1;                 \
     } while (0)
 
 static void bb_spi_burst(uint8_t *data, int len, bool lock)
@@ -51,7 +52,7 @@ static void bb_spi_burst(uint8_t *data, int len, bool lock)
     }
     CS_RELEASE_HIGH();
     // Release MOSI to input (pull-up high) after the last bit.
-    P0CR &= (uint8_t)~_P0_7;
+    GPIO_INPUT(0, RF_BB_SPI_MOSI_P0_7);
     RF_BB_SPI_MOSI = 1;
     MOT_RELEASE_HIGH();
 }
@@ -81,19 +82,22 @@ uint8_t bb_spi_xfer_byte(uint8_t data)
 {
     uint8_t recv = 0;
 
+    // Per-bit open-drain bit-bang: SCK low, set MOSI, sample MISO, release SCK
+    // high. MISO is sampled while SCK is LOW - the slave latches it on the SCK
+    // falling edge, so the master must read before releasing SCK high again.
     for (uint8_t i = 0; i < 8; i++) {
         recv = recv << 1;
 
         RF_BB_SPI_SCK = 0;
-        P4CR |= _P4_7;
+        GPIO_OUTPUT(4, RF_BB_SPI_SCK_P4_7);
         RF_BB_SPI_SCK = 0;
 
         if (data & (1 << 7)) {
-            P0CR &= (uint8_t)~_P0_7; // MOSI -> input, pull-up to high
+            GPIO_INPUT(0, RF_BB_SPI_MOSI_P0_7); // MOSI -> input, pull-up to high
             RF_BB_SPI_MOSI = 1;
         } else {
             RF_BB_SPI_MOSI = 0;
-            P0CR |= _P0_7; // MOSI -> output, drives low
+            GPIO_OUTPUT(0, RF_BB_SPI_MOSI_P0_7); // MOSI -> output, drives low
             RF_BB_SPI_MOSI = 0;
         }
 
@@ -101,7 +105,7 @@ uint8_t bb_spi_xfer_byte(uint8_t data)
             recv |= 0x01;
         }
 
-        P4CR &= (uint8_t)~_P4_7;
+        GPIO_INPUT(4, RF_BB_SPI_SCK_P4_7);
         RF_BB_SPI_SCK = 1;
 
         data = data << 1;

--- a/src/platform/bk3632/rf_controller.c
+++ b/src/platform/bk3632/rf_controller.c
@@ -55,10 +55,10 @@ void    rf_cmd_03(uint8_t param);
 void    rf_cmd_04();
 void    rf_send_consumer_system(uint16_t consumer, uint16_t system);
 void    rf_cmd_06(uint8_t param);
-void    rf_prepare_sleep(uint8_t param);
+void    rf_sleep(uint8_t param);
 void    rf_set_bt_name(uint8_t type, char *name);
 void    rf_query_status();
-void    rf_wake_from_sleep();
+void    rf_wake();
 void    rf_wake_nudge();
 void    rf_fetch_4();
 uint8_t checksum(uint8_t *data, int len);
@@ -105,9 +105,9 @@ void rf_factory_reset_bonds(void)
 {
     rf_cmd_03(2); // wipe stored bonds
     delay_ms(200);
-    rf_prepare_sleep(0);
+    rf_sleep(0);
     delay_ms(100);
-    rf_wake_from_sleep();
+    rf_wake();
     delay_ms(200);
     rf_init(); // reload BT names cleared by the wipe + sleep cycle
     delay_ms(200);
@@ -175,7 +175,7 @@ bool rf_update_keyboard_state(keyboard_state_t *keyboard)
     uint8_t status_bytes[2];
 
     if (!rf_get_status(status_bytes)) {
-        return false;
+        return false; // no fresh status - leave keyboard_state untouched
     }
 
     if (!(status_bytes[0] & 0x80)) {
@@ -275,7 +275,6 @@ void rf_blanking_tick(void)
     rf_send_kro_report(buf);
     blanking_active = false;
 }
-
 static uint8_t pairing_status_bytes[2];
 static uint8_t pairing_paired_now;
 
@@ -347,7 +346,7 @@ void rf_fetch_4()
 
     bb_spi_recv(rf_tx_buf, 4);
 }
-
+// Never nudge between attempts: it reuses rf_tx_buf and corrupts the in-flight report.
 #define RF_SEND_MAX_ATTEMPTS 5
 
 static bool rf_send_or_retry(uint8_t *buf, int len)
@@ -554,7 +553,7 @@ void rf_cmd_06(uint8_t param) // 0x00 or 0x01
     bb_spi_xfer(rf_tx_buf, len);
 }
 
-void rf_prepare_sleep(uint8_t param)
+void rf_sleep(uint8_t param)
 {
     const uint8_t len = 6;
 
@@ -614,7 +613,7 @@ void rf_query_status()
     bb_spi_xfer(rf_tx_buf, len);
 }
 
-void rf_wake_from_sleep()
+void rf_wake()
 {
     const uint8_t len = 6;
 

--- a/src/platform/bk3632/rf_controller.h
+++ b/src/platform/bk3632/rf_controller.h
@@ -13,28 +13,25 @@ typedef enum {
 } rf_mode_t;
 
 void rf_init();
+
 void rf_send_report(__xdata report_keyboard_t *report);
 void rf_send_nkro(__xdata report_nkro_t *report);
 void rf_send_extra(__xdata report_extra_t *report);
-bool rf_update_keyboard_state(keyboard_state_t *keyboard);
-void rf_set_link(rf_mode_t link);
-void rf_set_link_pairing(rf_mode_t link, __xdata keyboard_state_t *keyboard);
-void rf_factory_reset_bonds(void);
-void rf_link_supervisor(keyboard_state_t *keyboard);
-void rf_reassert_link(rf_mode_t link);
-
-void rf_apply_usb_mode(void);
-
-void rf_set_mac_mode_compat(bool is_mac);
-
-void rf_byte9_set_disable(bool on);
-
+void rf_send_pending_flush(void);
+void rf_blanking_tick(void);
 void rf_kbd_lazy_state_init(void);
 
-void rf_send_pending_flush(void);
+bool rf_update_keyboard_state(keyboard_state_t *keyboard);
+void rf_link_supervisor(keyboard_state_t *keyboard);
+void rf_set_link(rf_mode_t link);
+void rf_set_link_pairing(rf_mode_t link, __xdata keyboard_state_t *keyboard);
+void rf_reassert_link(rf_mode_t link);
+void rf_apply_usb_mode(void);
+void rf_factory_reset_bonds(void);
 
-void rf_blanking_tick(void);
+void rf_set_mac_mode_compat(bool is_mac);
+void rf_byte9_set_disable(bool on);
 
-void rf_prepare_sleep(uint8_t param);
-void rf_wake_from_sleep(void);
+void rf_sleep(uint8_t param);
+void rf_wake(void);
 void rf_wake_nudge(void);

--- a/src/platform/sh68f90a/clock.c
+++ b/src/platform/sh68f90a/clock.c
@@ -16,21 +16,27 @@ void clock_init()
     CLKCON |= _FS;
 }
 
+static void hf_oscillator_settle(void)
+{
+    for (uint8_t i = 0; i < 200; i++) {
+        // clang-format off
+        __asm
+            nop
+        __endasm;
+        // clang-format on
+    }
+}
+
 void clock_wake_restart()
 {
+    // PLLSTA trips before a cold-started oscillator is USB-stable; settle by delay instead.
     __critical
     {
         CLKCON |= _HFON;
         PLLCON |= _PLLON;
         watchdog_kick();
 
-        for (uint8_t i = 0; i < 200; i++) {
-            // clang-format off
-            __asm
-                nop
-            __endasm;
-            // clang-format on
-        }
+        hf_oscillator_settle();
 
         PLLCON = _PLLFS | _PLLON;
         CLKCON = _FS | _HFON;

--- a/src/platform/sh68f90a/flash.c
+++ b/src/platform/sh68f90a/flash.c
@@ -2,13 +2,12 @@
 #include "sh68f90a.h"
 #include <stdbool.h>
 
-#define CFG_ADDR   0xEC00u // flash sector 118 (0xEC00..0xEDFF)
+#define CFG_ADDR   0xEC00u // sector 118
 #define CFG_SIZE   512u
 #define CFG_END    (CFG_ADDR + CFG_SIZE)
 #define CFG_MAGIC0 0x5Au
 #define CFG_MAGIC1 0xA5u
-// record layout: [magic0][magic1][len][payload x len][checksum]
-#define CFG_HDR 3u // magic0, magic1, len precede the payload
+#define CFG_HDR    3u
 
 _Static_assert((CFG_ADDR & (CFG_SIZE - 1)) == 0, "CFG_ADDR must be aligned to a 512-byte flash sector boundary");
 _Static_assert(CFG_END <= 0xEE00u, "CFG_END must not reach sector 119 (holds reset-vector redirect at 0xEFFC)");
@@ -27,6 +26,11 @@ static uint8_t flash_read(uint16_t addr)
 {
     __code uint8_t *p = (__code uint8_t *)addr;
     return *p;
+}
+
+static uint16_t payload_addr(uint8_t i)
+{
+    return (uint16_t)(CFG_ADDR + CFG_HDR + i);
 }
 
 static void ssp_run(uint16_t addr, uint8_t op, uint8_t data)
@@ -68,39 +72,42 @@ static void flash_program(uint16_t addr, uint8_t data)
     ssp_run(addr, SSP_PROGRAM, data);
 }
 
+static bool record_header_valid(uint8_t len)
+{
+    return flash_read(CFG_ADDR) == CFG_MAGIC0 && flash_read(CFG_ADDR + 1) == CFG_MAGIC1 && flash_read(CFG_ADDR + 2) == len;
+}
+
 static bool stored_record_matches(const __xdata uint8_t *src, uint8_t len)
 {
-    if (flash_read(CFG_ADDR) != CFG_MAGIC0 || flash_read(CFG_ADDR + 1) != CFG_MAGIC1 || flash_read(CFG_ADDR + 2) != len) {
+    if (!record_header_valid(len)) {
         return false;
     }
 
     for (uint8_t i = 0; i < len; i++) {
-        if (flash_read((uint16_t)(CFG_ADDR + CFG_HDR + i)) != src[i]) {
+        if (flash_read(payload_addr(i)) != src[i]) {
             return false;
         }
     }
     return true;
 }
 
-bool flash_settings_load(__xdata uint8_t *dst, uint8_t len)
+static bool record_checksum_valid(uint8_t len)
 {
-    if (flash_read(CFG_ADDR) != CFG_MAGIC0 || flash_read(CFG_ADDR + 1) != CFG_MAGIC1) {
-        return false;
-    }
-    if (flash_read(CFG_ADDR + 2) != len) {
-        return false;
-    }
-
     uint8_t sum = 0;
     for (uint8_t i = 0; i < len; i++) {
-        sum += flash_read((uint16_t)(CFG_ADDR + CFG_HDR + i));
+        sum += flash_read(payload_addr(i));
     }
-    if (flash_read((uint16_t)(CFG_ADDR + CFG_HDR + len)) != sum) {
-        return false; // checksum mismatch
+    return flash_read(payload_addr(len)) == sum;
+}
+
+bool flash_settings_load(__xdata uint8_t *dst, uint8_t len)
+{
+    if (!record_header_valid(len) || !record_checksum_valid(len)) {
+        return false;
     }
 
     for (uint8_t i = 0; i < len; i++) {
-        dst[i] = flash_read((uint16_t)(CFG_ADDR + CFG_HDR + i));
+        dst[i] = flash_read(payload_addr(i));
     }
     return true;
 }
@@ -111,6 +118,7 @@ void flash_settings_save(const __xdata uint8_t *src, uint8_t len)
         return;
     }
 
+    // A sector only programs after an erase, so every change rewrites the record.
     flash_erase_config();
     flash_program(CFG_ADDR + 0, CFG_MAGIC0);
     flash_program(CFG_ADDR + 1, CFG_MAGIC1);
@@ -118,8 +126,8 @@ void flash_settings_save(const __xdata uint8_t *src, uint8_t len)
 
     uint8_t sum = 0;
     for (uint8_t i = 0; i < len; i++) {
-        flash_program((uint16_t)(CFG_ADDR + CFG_HDR + i), src[i]);
+        flash_program(payload_addr(i), src[i]);
         sum += src[i];
     }
-    flash_program((uint16_t)(CFG_ADDR + CFG_HDR + len), sum);
+    flash_program(payload_addr(len), sum);
 }

--- a/src/platform/sh68f90a/power.c
+++ b/src/platform/sh68f90a/power.c
@@ -6,14 +6,10 @@
 #include "clock.h"
 #include "extint.h"
 
-#define SUSLO_POWERDOWN_KEY 0x55
-// Keep the pending bus-event flags, drop the ones we have handled.
+#define SUSLO_POWERDOWN_KEY     0x55
 #define USBIF1_BUS_EVENTS_CLEAR (uint8_t)(_SUSPIF | _SOFIF | _SETUPIF | _OW | _OVERIF)
 #define USBIE1_RESUME_ARM       (uint8_t)(_PBRSTIE | _SUSPIE | _RESMIE | _SOFIA | _SETUPIE | _OVERIE)
-#define REGULATOR_SETTLE_US     500 // datasheet 8.1
-
-// Datasheet 8.9.3: in Power-Down only INT2/3/4, LPD, a USB bus event or reset
-// wakes the core.
+#define REGULATOR_SETTLE_US     500
 
 static volatile uint8_t int4_woke;
 

--- a/src/platform/sh68f90a/power.c
+++ b/src/platform/sh68f90a/power.c
@@ -4,10 +4,16 @@
 #include "delay.h"
 #include "usb.h"
 #include "clock.h"
+#include "extint.h"
 
-#define SUSLO_POWERDOWN_KEY     0x55
+#define SUSLO_POWERDOWN_KEY 0x55
+// Keep the pending bus-event flags, drop the ones we have handled.
 #define USBIF1_BUS_EVENTS_CLEAR (uint8_t)(_SUSPIF | _SOFIF | _SETUPIF | _OW | _OVERIF)
 #define USBIE1_RESUME_ARM       (uint8_t)(_PBRSTIE | _SUSPIE | _RESMIE | _SOFIA | _SETUPIE | _OVERIE)
+#define REGULATOR_SETTLE_US     500 // datasheet 8.1
+
+// Datasheet 8.9.3: in Power-Down only INT2/3/4, LPD, a USB bus event or reset
+// wakes the core.
 
 static volatile uint8_t int4_woke;
 
@@ -17,7 +23,6 @@ static void usb_park(powerdown_mode_t mode)
         USBCON |= _GOSUSP;
         return;
     }
-
     usb_deinit();
 }
 
@@ -69,7 +74,6 @@ static void usb_resume(powerdown_mode_t mode)
 {
     USBIF1 &= ~_SUSPIF;
     USBCON &= ~_GOSUSP;
-
     if (int4_woke) {
         USBCON |= _WKUP;
         int4_woke = 0;
@@ -83,7 +87,7 @@ static void usb_resume(powerdown_mode_t mode)
     }
 
     REGCON |= _REGEN;
-    delay_us(500);
+    delay_us(REGULATOR_SETTLE_US);
     usb_init();
 }
 
@@ -97,13 +101,12 @@ void power_enter_powerdown(powerdown_mode_t mode)
     int4_woke = 0;
 
     halt_until_wake();
-
     clock_wake_restart();
     usb_resume(mode);
 }
 
 void int4_interrupt_handler(void) __interrupt(_INT_INT4)
 {
-    EXF1      = 0;
+    extint_wake_clear();
     int4_woke = 1;
 }

--- a/src/platform/sh68f90a/stack.c
+++ b/src/platform/sh68f90a/stack.c
@@ -44,7 +44,7 @@ void stack_task(void)
     uint8_t peak = stack_peak();
     if (peak > reported) {
         reported = peak;
-        dprintf("SPpk %02x\r\n", peak);
+        dprintf("STACK peak: %02x\r\n", peak);
     }
 }
 

--- a/src/smk/report.c
+++ b/src/smk/report.c
@@ -158,16 +158,20 @@ void del_key_byte(report_keyboard_t *keyboard_report, uint8_t code)
 #ifdef NKRO_ENABLE
 void add_key_bit(report_nkro_t *nkro_report, uint8_t code)
 {
-    if ((code >> 3) < NKRO_REPORT_BITS) {
-        nkro_report->bits[code >> 3] |= 1 << (code & 7);
+    if ((code >> 3) >= NKRO_REPORT_BITS) {
+        dprintf("nkro add out of range %02x\r\n", code);
+        return;
     }
+    nkro_report->bits[code >> 3] |= 1 << (code & 7);
 }
 
 void del_key_bit(report_nkro_t *nkro_report, uint8_t code)
 {
-    if ((code >> 3) < NKRO_REPORT_BITS) {
-        nkro_report->bits[code >> 3] &= ~(1 << (code & 7));
+    if ((code >> 3) >= NKRO_REPORT_BITS) {
+        dprintf("nkro del out of range %02x\r\n", code);
+        return;
     }
+    nkro_report->bits[code >> 3] &= ~(1 << (code & 7));
 }
 #endif
 
@@ -230,8 +234,6 @@ uint8_t get_weak_mods(void)
     return weak_mods;
 }
 
-// most significant on-bit - return highest location of on-bit
-// NOTE: return 0 when bit0 is on or all bits are off
 uint8_t biton(uint8_t bits)
 {
     uint8_t n = 0;

--- a/src/smk/report.h
+++ b/src/smk/report.h
@@ -12,7 +12,6 @@
 
 #define EXTRA_REPORT_SIZE 3
 
-// debug console: text payload bytes per HID report (excludes the report id byte)
 #define CONSOLE_REPORT_SIZE 32
 
 enum report_id {
@@ -102,35 +101,30 @@ void    clear_mods(void);
  * See https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf#page=75
  */
 enum consumer_usages {
-    // 15.5 Display Controls
-    SNAPSHOT        = 0x065,
-    BRIGHTNESS_UP   = 0x06F, // https://www.usb.org/sites/default/files/hutrr41_0.pdf
-    BRIGHTNESS_DOWN = 0x070,
-    // 15.7 Transport Controls
-    TRANSPORT_RECORD       = 0x0B2,
-    TRANSPORT_FAST_FORWARD = 0x0B3,
-    TRANSPORT_REWIND       = 0x0B4,
-    TRANSPORT_NEXT_TRACK   = 0x0B5,
-    TRANSPORT_PREV_TRACK   = 0x0B6,
-    TRANSPORT_STOP         = 0x0B7,
-    TRANSPORT_EJECT        = 0x0B8,
-    TRANSPORT_RANDOM_PLAY  = 0x0B9,
-    TRANSPORT_STOP_EJECT   = 0x0CC,
-    TRANSPORT_PLAY_PAUSE   = 0x0CD,
-    // 15.9.1 Audio Controls - Volume
-    AUDIO_MUTE     = 0x0E2,
-    AUDIO_VOL_UP   = 0x0E9,
-    AUDIO_VOL_DOWN = 0x0EA,
-    // 15.15 Application Launch Buttons
-    AL_CC_CONFIG       = 0x183,
-    AL_EMAIL           = 0x18A,
-    AL_CALCULATOR      = 0x192,
-    AL_LOCAL_BROWSER   = 0x194,
-    AL_LOCK            = 0x19E,
-    AL_CONTROL_PANEL   = 0x19F,
-    AL_ASSISTANT       = 0x1CB,
-    AL_KEYBOARD_LAYOUT = 0x1AE,
-    // 15.16 Generic GUI Application Controls
+    SNAPSHOT                       = 0x065,
+    BRIGHTNESS_UP                  = 0x06F, // https://www.usb.org/sites/default/files/hutrr41_0.pdf
+    BRIGHTNESS_DOWN                = 0x070,
+    TRANSPORT_RECORD               = 0x0B2,
+    TRANSPORT_FAST_FORWARD         = 0x0B3,
+    TRANSPORT_REWIND               = 0x0B4,
+    TRANSPORT_NEXT_TRACK           = 0x0B5,
+    TRANSPORT_PREV_TRACK           = 0x0B6,
+    TRANSPORT_STOP                 = 0x0B7,
+    TRANSPORT_EJECT                = 0x0B8,
+    TRANSPORT_RANDOM_PLAY          = 0x0B9,
+    TRANSPORT_STOP_EJECT           = 0x0CC,
+    TRANSPORT_PLAY_PAUSE           = 0x0CD,
+    AUDIO_MUTE                     = 0x0E2,
+    AUDIO_VOL_UP                   = 0x0E9,
+    AUDIO_VOL_DOWN                 = 0x0EA,
+    AL_CC_CONFIG                   = 0x183,
+    AL_EMAIL                       = 0x18A,
+    AL_CALCULATOR                  = 0x192,
+    AL_LOCAL_BROWSER               = 0x194,
+    AL_LOCK                        = 0x19E,
+    AL_CONTROL_PANEL               = 0x19F,
+    AL_ASSISTANT                   = 0x1CB,
+    AL_KEYBOARD_LAYOUT             = 0x1AE,
     AC_NEW                         = 0x201,
     AC_OPEN                        = 0x202,
     AC_CLOSE                       = 0x203,
@@ -163,7 +157,6 @@ enum consumer_usages {
  * See https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf#page=26
  */
 enum desktop_usages {
-    // 4.5.1 System Controls - Power Controls
     SYSTEM_POWER_DOWN = 1 << 0,
     SYSTEM_SLEEP      = 1 << 1,
     SYSTEM_WAKE_UP    = 1 << 2,

--- a/src/smk/settings.h
+++ b/src/smk/settings.h
@@ -4,8 +4,8 @@
 #include <stdbool.h>
 
 typedef struct {
-    uint8_t led_effect;     // selected backlight effect (or "off")
-    uint8_t led_brightness; // 0 (dark) .. 255 (full)
+    uint8_t led_effect;
+    uint8_t led_brightness;
     uint8_t led_speed;
     uint8_t ul_effect;
     uint8_t ul_brightness;

--- a/src/smk/sleep.c
+++ b/src/smk/sleep.c
@@ -107,7 +107,7 @@ void sleep_task(void)
 
 #    ifdef RF_ENABLED
     if (powerdown == POWERDOWN_RELEASE_USB) {
-        rf_wake_from_sleep();
+        rf_wake();
     }
 #    endif
 

--- a/utils/check_isr_overlay.py
+++ b/utils/check_isr_overlay.py
@@ -7,7 +7,7 @@ each non-reentrant function's locals/params into a shared "overlay" area (OSEG /
 BIT_BANK) to save RAM, reusing the same internal-RAM bytes for functions it thinks
 never run at once. That analysis does NOT account for interrupt preemption, so it
 will happily park a USB-ISR helper's pointer on the very bytes a main-loop function
-is using — and the ISR then corrupts it mid-render. The concrete failure was a hung
+is using - and the ISR then corrupts it mid-render. The concrete failure was a hung
 `__gptrput` (a stomped generic-pointer type byte → its code-space `sjmp .` trap).
 
 This check reconstructs the call graph from the generated .asm, marks every function
@@ -19,7 +19,7 @@ Assumptions / limits:
   * Interrupts are equal-priority (no nesting), so ISR<->ISR overlay sharing is
     safe and not flagged; only ISR<->main sharing is.
   * The call graph is built from direct lcall/ljmp edges. Calls made through
-    function pointers are invisible here — don't dispatch ISR work indirectly.
+    function pointers are invisible here - don't dispatch ISR work indirectly.
 """
 import argparse
 import glob
@@ -32,7 +32,7 @@ import sys
 SAFE = {"__gptrput", "__gptrget"}
 
 # Overlay areas that hold per-function locals/params. REG_BANK_* is saved/restored
-# by the ISR prologue; SSEG is the stack — neither is an overlay-collision hazard.
+# by the ISR prologue; SSEG is the stack - neither is an overlay-collision hazard.
 OVERLAY_AREAS = {"OSEG", "BIT_BANK"}
 
 
@@ -97,7 +97,7 @@ def overlay_slots(map_file):
 
     Every overlay entry appears under two symbols: a module-qualified `Lmod.func$var`
     form and a short `_func_...` form. The linker truncates the "Global" column at ~32
-    chars, which can cut the function name out of the long L-form — but the short form
+    chars, which can cut the function name out of the long L-form - but the short form
     (no module prefix) resolves, so a truncated L-form is always redundant and dropped
     silently. Anything else unresolved is a genuine blind spot and is returned.
     """

--- a/utils/sdcc_compile.py
+++ b/utils/sdcc_compile.py
@@ -5,9 +5,9 @@ SDCC's -M family (-M/-MM/-MD/-MMD) is *deps-only*: it writes the dependency list
 but suppresses code generation, leaving an empty .rel. GCC's -MMD does both in one
 pass; SDCC can't, so we invoke it twice:
 
-  1. `sdcc <args> -MMD -MF=<depfile>` — writes <depfile> (its target is the -o
+  1. `sdcc <args> -MMD -MF=<depfile>` - writes <depfile> (its target is the -o
      value, so it matches what ninja expects) and truncates the .rel to empty.
-  2. `sdcc <args>` — the real compile, refilling the .rel.
+  2. `sdcc <args>` - the real compile, refilling the .rel.
 
 Step 2's exit status is authoritative; step 1 is best-effort so a dependency-scan
 hiccup never fails an otherwise-good build (worst case: that one .rel just isn't
@@ -21,8 +21,8 @@ import sys
 depfile = sys.argv[1]
 cmd = sys.argv[2:]  # sdcc + all flags, ending in -c <input> -o <output.rel>
 
-# 1. dependency scan (also empties the .rel — that's why the real compile follows)
+# 1. dependency scan (also empties the .rel - that's why the real compile follows)
 subprocess.run(cmd + ["-MMD", "-MF=" + depfile])
 
-# 2. real compile — refills the .rel; this is the status the build acts on
+# 2. real compile - refills the .rel; this is the status the build acts on
 sys.exit(subprocess.run(cmd).returncode)


### PR DESCRIPTION
Replaces raw hex in the platform layer with names built from the documented bit definitions, names the PWM channel-control values, routes the INT4 flag clear through extint, and makes a nuphy-air60 build with DEBUG_SINK_UART fail at compile time rather than silently fighting CONN_MODE_SWITCH for P5.5.