### PR TITLE
sh68f90a: read the factory information block

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,7 @@ src_platform_sh68f90a = [
     'src/platform/sh68f90a/startup.c',
     'src/platform/sh68f90a/clock.c',
     'src/platform/sh68f90a/delay.c',
+    'src/platform/sh68f90a/diag.c',
     'src/platform/sh68f90a/flash.c',
     'src/platform/sh68f90a/isp.c',
     'src/platform/sh68f90a/ldo.c',

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "settings.h"
 #include "tick.h"
 #include "sleep.h"
+#include "diag.h"
 #ifdef DEBUG_SINK_UART
 #    include "uart.h"
 #endif
@@ -107,6 +108,7 @@ void main(void)
 
 #if DEBUG == 1
         stack_task();
+        diag_task();
         console_task();
 #endif
     }

--- a/src/platform/sh68f90a/diag.c
+++ b/src/platform/sh68f90a/diag.c
@@ -1,0 +1,114 @@
+#include "diag.h"
+
+#if DEBUG == 1
+
+#    include "sh68f90a.h"
+#    include "console.h"
+#    include "debug.h"
+#    include <stdint.h>
+
+// Information block layout in the address space MOVC sees while FAC is set; the same map a programmer reaches over ICP.
+#    define INFO_CUSTOMER_ID     0x1000u
+#    define INFO_OPERATION_NUM   0x1004u
+#    define INFO_CODE_OPTION_LOW 0x1006u
+#    define INFO_SECURITY        0x100Au
+#    define INFO_SERIAL_NUMBER   0x103Cu
+#    define INFO_CODE_OPTION_HI  0x1100u
+#    define INFO_PART_NUMBER     0x1209u
+#    define INFO_ID_CODE         0x127Bu
+
+#    define INFO_SECURITY_LEN 17u
+#    define CODE_OPTION_LEN   8u
+#    define CODE_OPTION_SPLIT 4u // bytes 0-3 sit with the customer fields, 4-7 stand alone
+
+// FLASHCON.FAC: point MOVC at the information block.
+#    define FLASHCON_FAC 0x01u
+
+static __xdata uint8_t scratch[INFO_SECURITY_LEN];
+
+static void info_read(uint16_t addr, __xdata uint8_t *dst, uint8_t len)
+{
+    // While FAC is set every MOVC hits the information block, so an ISR firing here would fetch its __code reads from the wrong place.
+    __critical
+    {
+        FLASHCON = FLASHCON_FAC;
+        for (uint8_t i = 0; i < len; i++) {
+            __code uint8_t *p = (__code uint8_t *)(addr + i);
+            dst[i]            = *p;
+        }
+        FLASHCON = 0;
+    }
+}
+
+static void emit_hex(const __xdata uint8_t *src, uint8_t len)
+{
+    for (uint8_t i = 0; i < len; i++) {
+        dprintf("%02x", src[i]);
+    }
+}
+
+static void diag_emit(uint8_t step)
+{
+    switch (step) {
+        case 0:
+            info_read(INFO_PART_NUMBER, scratch, 5);
+            dprintf("PART ");
+            emit_hex(scratch, 5);
+            dprintf("\r\n");
+            break;
+        case 1:
+            info_read(INFO_ID_CODE, scratch, 5);
+            dprintf("UID ");
+            emit_hex(scratch, 5);
+            dprintf("\r\n");
+            break;
+        case 2:
+            info_read(INFO_CUSTOMER_ID, scratch, 4);
+            dprintf("CID ");
+            emit_hex(scratch, 4);
+            info_read(INFO_OPERATION_NUM, scratch, 2);
+            dprintf(" OPN ");
+            emit_hex(scratch, 2);
+            dprintf("\r\n");
+            break;
+        case 3:
+            info_read(INFO_SERIAL_NUMBER, scratch, 4);
+            dprintf("SN ");
+            emit_hex(scratch, 4);
+            dprintf("\r\n");
+            break;
+        case 4:
+            info_read(INFO_SECURITY, scratch, INFO_SECURITY_LEN);
+            dprintf("SEC ");
+            emit_hex(scratch, INFO_SECURITY_LEN);
+            dprintf("\r\n");
+            break;
+        case 5:
+            info_read(INFO_CODE_OPTION_LOW, scratch, CODE_OPTION_SPLIT);
+            info_read(INFO_CODE_OPTION_HI, scratch + CODE_OPTION_SPLIT, CODE_OPTION_LEN - CODE_OPTION_SPLIT);
+            dprintf("OPT ");
+            emit_hex(scratch, CODE_OPTION_LEN);
+            dprintf("\r\n");
+            break;
+        default:
+            break;
+    }
+}
+
+#    define DIAG_STEPS 6u
+
+void diag_task(void)
+{
+    static uint8_t step = 0;
+
+    if (step >= DIAG_STEPS) {
+        return;
+    }
+    // Emitting only into a drained buffer paces the dump against the host link, so no line is ever dropped however long the dump grows.
+    if (!console_is_drained()) {
+        return;
+    }
+    diag_emit(step++);
+}
+
+#endif // DEBUG

--- a/src/platform/sh68f90a/diag.h
+++ b/src/platform/sh68f90a/diag.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Dumps the factory information block to the debug console, one line per call so a long dump never outruns the ring buffer. DEBUG builds only.
+
+void diag_task(void);

--- a/src/smk/console.c
+++ b/src/smk/console.c
@@ -105,6 +105,11 @@ void console_notify_attached(void)
     console_attached = 1;
 }
 
+bool console_is_drained(void)
+{
+    return console_attached && console_head == console_tail;
+}
+
 void console_putc(unsigned char c)
 {
     uint8_t next;

--- a/src/smk/console.h
+++ b/src/smk/console.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // Debug console over the host link. Bytes written with console_putc() are queued
 // in a ring buffer and drained to the host by console_task(), which must be
@@ -18,5 +19,8 @@ void debug_putc(char c);
 void console_task(void);
 
 void console_notify_attached(void);
+
+// True once the host is listening and everything queued has gone out, so a long dump can pace itself a line at a time.
+bool console_is_drained(void);
 
 void console_printf(const __code char *fmt, ...) __reentrant;


### PR DESCRIPTION
Setting `FLASHCON.FAC` points `MOVC` at the information block instead of the main block, making the chip identity and code-option fuses readable from firmware. Adds a DEBUG-only `diag_task()` that dumps them, verified on a nuphy-air60 against what a programmer reads over ICP.